### PR TITLE
fix(proposals): retype depositOptions.treasuryDonation as lovelace integer

### DIFF
--- a/api/proposals/openapi.yaml
+++ b/api/proposals/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Ekklesia Proposals API
-  version: 0.1.1
+  version: 0.1.2
   description: >
     The Ekklesia Proposals API provides endpoints for decentralized governance
     proposal management on the Cardano blockchain. It supports session-based
@@ -1467,8 +1467,12 @@ components:
           description: Treasury deposit configuration.
           properties:
             treasuryDonation:
-              type: boolean
-              description: Whether a treasury donation transaction is required.
+              type: integer
+              format: int64
+              minimum: 0
+              description: >
+                Required treasury donation amount in lovelace. 0 means no
+                donation is required.
             depositAddress:
               type: string
               description: Address for treasury deposits, if applicable.

--- a/downloads/_files/ekklesia-proposals-api.postman_collection.json
+++ b/downloads/_files/ekklesia-proposals-api.postman_collection.json
@@ -9,7 +9,7 @@
                     "description": "",
                     "item": [
                         {
-                            "id": "c00d1003-ee47-4d77-b0f9-3257c3c29c1b",
+                            "id": "42dc0c2c-df71-4556-9013-67c572d36ee1",
                             "name": "Health check",
                             "request": {
                                 "name": "Health check",
@@ -40,7 +40,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "a4cd93dd-6ffc-40ca-a572-17a6907b92af",
+                                    "id": "0af4e63b-1aa2-4950-b8fc-98511176f1b4",
                                     "name": "API is healthy.",
                                     "originalRequest": {
                                         "url": {
@@ -90,7 +90,7 @@
             "description": "",
             "item": [
                 {
-                    "id": "0d965320-50a9-4d7e-a753-364fcd9cc00c",
+                    "id": "84115abe-7f99-4e40-bcf4-3070a148011b",
                     "name": "Request authentication nonce",
                     "request": {
                         "name": "Request authentication nonce",
@@ -133,7 +133,7 @@
                     },
                     "response": [
                         {
-                            "id": "3334cfe3-9852-4170-a382-e774d608c4d5",
+                            "id": "d2429942-aed5-4115-9064-84739a110bdb",
                             "name": "Nonce generated successfully.",
                             "originalRequest": {
                                 "url": {
@@ -181,7 +181,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e6c5326e-9a4e-48a6-aa95-472c65614ab8",
+                            "id": "7a888b4e-1841-48cb-b2f1-5f21cd6b7fdf",
                             "name": "Invalid request. Possible reasons: missing or invalid signer address, script address errors.",
                             "originalRequest": {
                                 "url": {
@@ -224,12 +224,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "6e3a2343-e7d2-4bb4-b3fa-1c3b6e415ebc",
+                            "id": "7c05a837-a094-4d5b-af6b-0cf3034b2f51",
                             "name": "Rate limit exceeded (5 requests per minute per IP).",
                             "originalRequest": {
                                 "url": {
@@ -272,7 +272,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -283,7 +283,7 @@
                     }
                 },
                 {
-                    "id": "eeca91f1-8974-4a40-8cb5-7fba0d86f348",
+                    "id": "8f8b89fe-22e0-426c-9673-6a06aa042de5",
                     "name": "Verify wallet signature",
                     "request": {
                         "name": "Verify wallet signature",
@@ -326,7 +326,7 @@
                     },
                     "response": [
                         {
-                            "id": "d071e2bc-9135-4baa-a882-3317c4ac40aa",
+                            "id": "65223d03-aa11-411f-9234-48f0ab3a67c5",
                             "name": "Signature verified. A JWT token is returned in the body and set as an HTTP-only cookie.",
                             "originalRequest": {
                                 "url": {
@@ -374,7 +374,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "89d0885a-c749-46a2-998e-c9309a19bf05",
+                            "id": "cdd45467-514a-4f70-b0f5-37bb3f944db6",
                             "name": "Invalid request. Possible reasons: nonce expired (5-minute TTL), signature verification failed, script address errors.",
                             "originalRequest": {
                                 "url": {
@@ -417,12 +417,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ff997611-7be5-4037-8138-d8368e06288d",
+                            "id": "6a294180-4d26-445b-b414-fdc81be89d1e",
                             "name": "Rate limit exceeded (10 requests per minute per IP).",
                             "originalRequest": {
                                 "url": {
@@ -465,7 +465,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -476,7 +476,7 @@
                     }
                 },
                 {
-                    "id": "b4e88ac8-2d7a-41a9-b3ae-104b8488bf98",
+                    "id": "03ce3d38-1343-44b6-a15c-197282699aef",
                     "name": "Check current session",
                     "request": {
                         "name": "Check current session",
@@ -522,7 +522,7 @@
                     },
                     "response": [
                         {
-                            "id": "9c7d7424-228c-4fae-bd1d-a8046b69e4af",
+                            "id": "b18d6157-a4da-4bfb-9ce0-520b20c38469",
                             "name": "Session is valid.",
                             "originalRequest": {
                                 "url": {
@@ -565,7 +565,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "4f35b9aa-a8fa-4f2a-bf8a-f0108ea10f30",
+                            "id": "7d96d283-7745-48cf-b2ea-dc90f07b6e2e",
                             "name": "Not authenticated or session expired.",
                             "originalRequest": {
                                 "url": {
@@ -603,12 +603,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "14a87afc-3da5-4a4a-933f-0b26d1755473",
+                            "id": "65baceff-576d-4439-8f07-1013401d0ee0",
                             "name": "Rate limit exceeded (60 requests per minute per IP).",
                             "originalRequest": {
                                 "url": {
@@ -646,7 +646,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -657,7 +657,7 @@
                     }
                 },
                 {
-                    "id": "bbcc3e49-9d8a-4c65-8876-36157672a1ca",
+                    "id": "320b9486-d13f-486b-83f0-af90b0f644a7",
                     "name": "Log out",
                     "request": {
                         "name": "Log out",
@@ -703,7 +703,7 @@
                     },
                     "response": [
                         {
-                            "id": "59b1325c-3786-4343-8fc8-928f7cbecd49",
+                            "id": "d9cf918c-8e56-42a7-8f10-223126af02e7",
                             "name": "Successfully logged out.",
                             "originalRequest": {
                                 "url": {
@@ -746,7 +746,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "eb260bde-cca5-419a-83ec-c92395683462",
+                            "id": "b834e25b-0436-43cb-94cc-7698955c60bf",
                             "name": "Not authenticated or session expired.",
                             "originalRequest": {
                                 "url": {
@@ -784,12 +784,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "bb3af2ae-409c-4fea-8ad0-ee493aef6fe3",
+                            "id": "cc60b363-a18b-4c0f-ba13-af0fe164035e",
                             "name": "Rate limit exceeded (20 requests per minute per IP).",
                             "originalRequest": {
                                 "url": {
@@ -827,7 +827,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -844,7 +844,7 @@
             "description": "",
             "item": [
                 {
-                    "id": "1d055906-afd4-453b-b5ce-ad17a3f2b474",
+                    "id": "23185bb4-ea71-468a-b39e-a5776e040efe",
                     "name": "List vote cycles",
                     "request": {
                         "name": "List vote cycles",
@@ -911,7 +911,7 @@
                     },
                     "response": [
                         {
-                            "id": "2cab8d59-c683-4043-be37-6a1f21214b85",
+                            "id": "4a50caef-d6b4-43a6-9f94-d078088eacd5",
                             "name": "Paginated list of vote cycles.",
                             "originalRequest": {
                                 "url": {
@@ -978,12 +978,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"data\": [\n    {\n      \"_id\": \"<string>\",\n      \"title\": \"<string>\",\n      \"description\": \"<string>\",\n      \"slug\": \"<string>\",\n      \"admins\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"submissionStartDate\": \"<dateTime>\",\n      \"submissionEndDate\": \"<dateTime>\",\n      \"feedbackStartDate\": \"<dateTime>\",\n      \"feedbackEndDate\": \"<dateTime>\",\n      \"reviewStartDate\": \"<dateTime>\",\n      \"reviewEndDate\": \"<dateTime>\",\n      \"form\": {},\n      \"commentsEnabled\": \"<boolean>\",\n      \"depositOptions\": {\n        \"treasuryDonation\": \"<boolean>\",\n        \"depositAddress\": \"<string>\",\n        \"depositAmount\": \"<number>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"votingUrl\": \"<string>\"\n    },\n    {\n      \"_id\": \"<string>\",\n      \"title\": \"<string>\",\n      \"description\": \"<string>\",\n      \"slug\": \"<string>\",\n      \"admins\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"submissionStartDate\": \"<dateTime>\",\n      \"submissionEndDate\": \"<dateTime>\",\n      \"feedbackStartDate\": \"<dateTime>\",\n      \"feedbackEndDate\": \"<dateTime>\",\n      \"reviewStartDate\": \"<dateTime>\",\n      \"reviewEndDate\": \"<dateTime>\",\n      \"form\": {},\n      \"commentsEnabled\": \"<boolean>\",\n      \"depositOptions\": {\n        \"treasuryDonation\": \"<boolean>\",\n        \"depositAddress\": \"<string>\",\n        \"depositAmount\": \"<number>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"votingUrl\": \"<string>\"\n    }\n  ],\n  \"meta\": {\n    \"page\": \"<integer>\",\n    \"limit\": \"<integer>\",\n    \"total\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"hasNextPage\": \"<boolean>\",\n    \"hasPreviousPage\": \"<boolean>\"\n  }\n}",
+                            "body": "{\n  \"data\": [\n    {\n      \"_id\": \"<string>\",\n      \"title\": \"<string>\",\n      \"description\": \"<string>\",\n      \"slug\": \"<string>\",\n      \"admins\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"submissionStartDate\": \"<dateTime>\",\n      \"submissionEndDate\": \"<dateTime>\",\n      \"feedbackStartDate\": \"<dateTime>\",\n      \"feedbackEndDate\": \"<dateTime>\",\n      \"reviewStartDate\": \"<dateTime>\",\n      \"reviewEndDate\": \"<dateTime>\",\n      \"form\": {},\n      \"commentsEnabled\": \"<boolean>\",\n      \"depositOptions\": {\n        \"treasuryDonation\": \"<long>\",\n        \"depositAddress\": \"<string>\",\n        \"depositAmount\": \"<number>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"votingUrl\": \"<string>\"\n    },\n    {\n      \"_id\": \"<string>\",\n      \"title\": \"<string>\",\n      \"description\": \"<string>\",\n      \"slug\": \"<string>\",\n      \"admins\": [\n        \"<string>\",\n        \"<string>\"\n      ],\n      \"submissionStartDate\": \"<dateTime>\",\n      \"submissionEndDate\": \"<dateTime>\",\n      \"feedbackStartDate\": \"<dateTime>\",\n      \"feedbackEndDate\": \"<dateTime>\",\n      \"reviewStartDate\": \"<dateTime>\",\n      \"reviewEndDate\": \"<dateTime>\",\n      \"form\": {},\n      \"commentsEnabled\": \"<boolean>\",\n      \"depositOptions\": {\n        \"treasuryDonation\": \"<long>\",\n        \"depositAddress\": \"<string>\",\n        \"depositAmount\": \"<number>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"votingUrl\": \"<string>\"\n    }\n  ],\n  \"meta\": {\n    \"page\": \"<integer>\",\n    \"limit\": \"<integer>\",\n    \"total\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"hasNextPage\": \"<boolean>\",\n    \"hasPreviousPage\": \"<boolean>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ae873974-319c-43cf-af3a-0f782bfd4310",
+                            "id": "324b5e77-e372-40cc-ad84-d2783a07f016",
                             "name": "Invalid request. Possible reasons: invalid pagination values, duplicate search or slug query parameters.",
                             "originalRequest": {
                                 "url": {
@@ -1050,12 +1050,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "db756069-ab55-4c49-9e1f-b49a0021189b",
+                            "id": "98454747-4a69-4c3d-aa27-b2b5066757ee",
                             "name": "No vote cycles match the provided search or slug filter.",
                             "originalRequest": {
                                 "url": {
@@ -1122,7 +1122,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -1137,7 +1137,7 @@
                     "description": "",
                     "item": [
                         {
-                            "id": "2dd0303b-daa2-4d7f-a955-6e6cd4a2e5c5",
+                            "id": "51e10788-6f2a-46a1-b129-198022c35831",
                             "name": "Get a vote cycle",
                             "request": {
                                 "name": "Get a vote cycle",
@@ -1179,7 +1179,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "f46642bd-c39e-4537-8f8a-a90e7ae7fcaa",
+                                    "id": "1c80db90-4418-420c-a421-859617dd4ddc",
                                     "name": "Vote cycle found.",
                                     "originalRequest": {
                                         "url": {
@@ -1221,12 +1221,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"_id\": \"<string>\",\n  \"title\": \"<string>\",\n  \"description\": \"<string>\",\n  \"slug\": \"<string>\",\n  \"admins\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"submissionStartDate\": \"<dateTime>\",\n  \"submissionEndDate\": \"<dateTime>\",\n  \"feedbackStartDate\": \"<dateTime>\",\n  \"feedbackEndDate\": \"<dateTime>\",\n  \"reviewStartDate\": \"<dateTime>\",\n  \"reviewEndDate\": \"<dateTime>\",\n  \"form\": {},\n  \"commentsEnabled\": \"<boolean>\",\n  \"depositOptions\": {\n    \"treasuryDonation\": \"<boolean>\",\n    \"depositAddress\": \"<string>\",\n    \"depositAmount\": \"<number>\"\n  },\n  \"sortOptions\": [],\n  \"filterOptions\": [],\n  \"searchOptions\": [],\n  \"createdAt\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"votingUrl\": \"<string>\"\n}",
+                                    "body": "{\n  \"_id\": \"<string>\",\n  \"title\": \"<string>\",\n  \"description\": \"<string>\",\n  \"slug\": \"<string>\",\n  \"admins\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"submissionStartDate\": \"<dateTime>\",\n  \"submissionEndDate\": \"<dateTime>\",\n  \"feedbackStartDate\": \"<dateTime>\",\n  \"feedbackEndDate\": \"<dateTime>\",\n  \"reviewStartDate\": \"<dateTime>\",\n  \"reviewEndDate\": \"<dateTime>\",\n  \"form\": {},\n  \"commentsEnabled\": \"<boolean>\",\n  \"depositOptions\": {\n    \"treasuryDonation\": \"<long>\",\n    \"depositAddress\": \"<string>\",\n    \"depositAmount\": \"<number>\"\n  },\n  \"sortOptions\": [],\n  \"filterOptions\": [],\n  \"searchOptions\": [],\n  \"createdAt\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"votingUrl\": \"<string>\"\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "5744af3e-90a4-43c8-8c44-7b28665d5a6f",
+                                    "id": "3b279d89-146e-41f3-b136-1c20cea56c73",
                                     "name": "Vote cycle not found.",
                                     "originalRequest": {
                                         "url": {
@@ -1268,7 +1268,7 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 }
@@ -1287,7 +1287,7 @@
             "description": "",
             "item": [
                 {
-                    "id": "00d1eda5-8bc7-41e8-a2cc-8a54a2ab1eee",
+                    "id": "cd9acbab-9b97-47b3-8b32-f0231e21dbe7",
                     "name": "Create a proposal",
                     "request": {
                         "name": "Create a proposal",
@@ -1318,7 +1318,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"voteId\": \"2fDCdC053f3d266b4d9DeEFe\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
+                            "raw": "{\n  \"voteId\": \"Bd2dcC0d51fcee36AECFCEeD\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -1346,7 +1346,7 @@
                     },
                     "response": [
                         {
-                            "id": "8f94a8fd-c542-4b34-bec6-3107adddb4c6",
+                            "id": "6238086f-09f8-4741-8e88-4b998558fdef",
                             "name": "Proposal created successfully.",
                             "originalRequest": {
                                 "url": {
@@ -1380,7 +1380,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"voteId\": \"2fDCdC053f3d266b4d9DeEFe\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
+                                    "raw": "{\n  \"voteId\": \"Bd2dcC0d51fcee36AECFCEeD\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1397,12 +1397,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"_id\": \"<string>\",\n  \"proposerId\": \"<string>\",\n  \"voteId\": \"<string>\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"live\",\n  \"metaData\": {},\n  \"version\": \"<integer>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"withdrawalDetails\": {\n    \"category\": \"Spam\",\n    \"userId\": \"<string>\",\n    \"date\": \"<dateTime>\",\n    \"comment\": \"<string>\"\n  },\n  \"versions\": [\n    {\n      \"_id\": \"<string>\",\n      \"createdAt\": \"<dateTime>\"\n    },\n    {\n      \"_id\": \"<string>\",\n      \"createdAt\": \"<dateTime>\"\n    }\n  ],\n  \"currentProposalId\": \"<string>\",\n  \"submittedAt\": \"<dateTime>\",\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
+                            "body": "{\n  \"_id\": \"<string>\",\n  \"proposerId\": \"<string>\",\n  \"voteId\": \"<string>\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"version\": \"<integer>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"withdrawalDetails\": {\n    \"category\": \"Duplicate submission\",\n    \"userId\": \"<string>\",\n    \"date\": \"<dateTime>\",\n    \"comment\": \"<string>\"\n  },\n  \"versions\": [\n    {\n      \"_id\": \"<string>\",\n      \"createdAt\": \"<dateTime>\"\n    },\n    {\n      \"_id\": \"<string>\",\n      \"createdAt\": \"<dateTime>\"\n    }\n  ],\n  \"currentProposalId\": \"<string>\",\n  \"submittedAt\": \"<dateTime>\",\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3f1f91cb-5b1a-4e8c-b776-f84c0e91956a",
+                            "id": "0a1db67e-58c5-4472-800f-b959dd98a935",
                             "name": "Invalid request. Possible reasons: validation errors, invalid voteId format, metaData does not match vote configuration.",
                             "originalRequest": {
                                 "url": {
@@ -1436,7 +1436,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"voteId\": \"2fDCdC053f3d266b4d9DeEFe\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
+                                    "raw": "{\n  \"voteId\": \"Bd2dcC0d51fcee36AECFCEeD\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1453,12 +1453,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c7c74c44-6419-4092-82d6-6faf8924d99c",
+                            "id": "5b95c1dc-d370-42ac-bccc-f31308d6e2b9",
                             "name": "Not authenticated.",
                             "originalRequest": {
                                 "url": {
@@ -1492,7 +1492,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"voteId\": \"2fDCdC053f3d266b4d9DeEFe\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
+                                    "raw": "{\n  \"voteId\": \"Bd2dcC0d51fcee36AECFCEeD\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1509,12 +1509,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "10ef6ec6-f6c9-43d8-a593-def842659c10",
+                            "id": "03fa075b-1bf2-4a1f-9692-8d9e4599863a",
                             "name": "Vote cycle not found.",
                             "originalRequest": {
                                 "url": {
@@ -1548,7 +1548,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"voteId\": \"2fDCdC053f3d266b4d9DeEFe\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
+                                    "raw": "{\n  \"voteId\": \"Bd2dcC0d51fcee36AECFCEeD\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1565,12 +1565,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ab5c467a-4065-4b03-9357-62e0bb8ad8d9",
+                            "id": "6a9f2a95-5a85-439f-b1f5-ae9859dc5e1e",
                             "name": "Rate limit exceeded (10 requests per minute per user).",
                             "originalRequest": {
                                 "url": {
@@ -1604,7 +1604,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"voteId\": \"2fDCdC053f3d266b4d9DeEFe\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
+                                    "raw": "{\n  \"voteId\": \"Bd2dcC0d51fcee36AECFCEeD\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1621,7 +1621,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -1632,12 +1632,12 @@
                     }
                 },
                 {
-                    "id": "ac56218b-b454-428e-9e62-f0919b07ef99",
+                    "id": "670e5906-fcc3-4117-8484-24eab2c5897d",
                     "name": "List proposals",
                     "request": {
                         "name": "List proposals",
                         "description": {
-                            "content": "Returns a paginated list of proposals for a given vote cycle. The vote query parameter is required. Draft proposals are only visible to the proposer or vote cycle admins.\n\nThe response includes a commentCount for each proposal and a shortened metaData object containing only key summary fields (proposerDetails.name, contractingParty.legalEntityType, strategyFramework.pillars, conversionRate, totalBudget).\n",
+                            "content": "Returns a paginated list of proposals for a given vote cycle. The vote query parameter is required. Draft proposals are only visible to the proposer or vote cycle admins.\n\n**List item projection is vote-configurable.** When the vote cycle defines a `listProjectionScript`, that script's `projectProposalListItem(proposal, { vote, isProposer, isAdmin })` is invoked per row and may add, omit, or reshape fields per the ballot's needs (for example, a budget cycle may expose `totalBudget` and a strategy-pillar summary that a generic cycle would not). When no projection script is configured (or the script throws), the fallback projection returns the full proposal minus internal-only fields (`withdrawalReason`, `signature`, `userId`) plus `commentCount`. Clients should treat `ProposalListItem` below as the conservative minimum and tolerate additional per-vote fields.\n",
                             "type": "text/plain"
                         },
                         "url": {
@@ -1655,7 +1655,7 @@
                                         "type": "text/plain"
                                     },
                                     "key": "vote",
-                                    "value": "C5FE5fdDbc2D74a71b70cf3B"
+                                    "value": "d1D36d221Aeba96D14Ed2acd"
                                 },
                                 {
                                     "disabled": false,
@@ -1744,7 +1744,7 @@
                     },
                     "response": [
                         {
-                            "id": "9d9465f4-f7de-47de-aa58-fe8735bf89b1",
+                            "id": "841cd0ae-00b3-444f-8e3a-fbffcfd0ff13",
                             "name": "Paginated list of proposals.",
                             "originalRequest": {
                                 "url": {
@@ -1762,7 +1762,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "vote",
-                                            "value": "C5FE5fdDbc2D74a71b70cf3B"
+                                            "value": "d1D36d221Aeba96D14Ed2acd"
                                         },
                                         {
                                             "disabled": false,
@@ -1856,12 +1856,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"data\": [\n    {\n      \"_id\": \"<string>\",\n      \"proposerId\": \"<string>\",\n      \"voteId\": \"<string>\",\n      \"title\": \"<string>\",\n      \"summary\": \"<string>\",\n      \"status\": \"withdrawnByAdmin\",\n      \"metaData\": {\n        \"proposerDetails\": {\n          \"name\": \"<string>\"\n        },\n        \"contractingParty\": {\n          \"legalEntityType\": \"<string>\"\n        },\n        \"strategyFramework\": {\n          \"pillars\": [\n            \"<string>\",\n            \"<string>\"\n          ]\n        },\n        \"conversionRate\": \"<number>\",\n        \"totalBudget\": \"<number>\"\n      },\n      \"version\": \"<integer>\",\n      \"commentCount\": \"<integer>\",\n      \"createdAt\": \"<dateTime>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"withdrawalDetails\": {\n        \"category\": \"Other\",\n        \"userId\": \"<string>\",\n        \"date\": \"<dateTime>\",\n        \"comment\": \"<string>\"\n      },\n      \"submittedAt\": \"<dateTime>\"\n    },\n    {\n      \"_id\": \"<string>\",\n      \"proposerId\": \"<string>\",\n      \"voteId\": \"<string>\",\n      \"title\": \"<string>\",\n      \"summary\": \"<string>\",\n      \"status\": \"withdrawnByAdmin\",\n      \"metaData\": {\n        \"proposerDetails\": {\n          \"name\": \"<string>\"\n        },\n        \"contractingParty\": {\n          \"legalEntityType\": \"<string>\"\n        },\n        \"strategyFramework\": {\n          \"pillars\": [\n            \"<string>\",\n            \"<string>\"\n          ]\n        },\n        \"conversionRate\": \"<number>\",\n        \"totalBudget\": \"<number>\"\n      },\n      \"version\": \"<integer>\",\n      \"commentCount\": \"<integer>\",\n      \"createdAt\": \"<dateTime>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"withdrawalDetails\": {\n        \"category\": \"Spam\",\n        \"userId\": \"<string>\",\n        \"date\": \"<dateTime>\",\n        \"comment\": \"<string>\"\n      },\n      \"submittedAt\": \"<dateTime>\"\n    }\n  ],\n  \"meta\": {\n    \"page\": \"<integer>\",\n    \"limit\": \"<integer>\",\n    \"total\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"hasNextPage\": \"<boolean>\",\n    \"hasPreviousPage\": \"<boolean>\"\n  }\n}",
+                            "body": "{\n  \"data\": [\n    {\n      \"_id\": \"<string>\",\n      \"proposerId\": \"<string>\",\n      \"voteId\": \"<string>\",\n      \"title\": \"<string>\",\n      \"summary\": \"<string>\",\n      \"status\": \"withdrawnByAdmin\",\n      \"metaData\": {\n        \"proposerDetails\": {\n          \"name\": \"<string>\"\n        },\n        \"contractingParty\": {\n          \"legalEntityType\": \"<string>\"\n        },\n        \"strategyFramework\": {\n          \"pillars\": [\n            \"<string>\",\n            \"<string>\"\n          ]\n        },\n        \"conversionRate\": \"<number>\",\n        \"totalBudget\": \"<number>\"\n      },\n      \"version\": \"<integer>\",\n      \"commentCount\": \"<integer>\",\n      \"createdAt\": \"<dateTime>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"withdrawalDetails\": {\n        \"category\": \"Spam\",\n        \"userId\": \"<string>\",\n        \"date\": \"<dateTime>\",\n        \"comment\": \"<string>\"\n      },\n      \"submittedAt\": \"<dateTime>\"\n    },\n    {\n      \"_id\": \"<string>\",\n      \"proposerId\": \"<string>\",\n      \"voteId\": \"<string>\",\n      \"title\": \"<string>\",\n      \"summary\": \"<string>\",\n      \"status\": \"live\",\n      \"metaData\": {\n        \"proposerDetails\": {\n          \"name\": \"<string>\"\n        },\n        \"contractingParty\": {\n          \"legalEntityType\": \"<string>\"\n        },\n        \"strategyFramework\": {\n          \"pillars\": [\n            \"<string>\",\n            \"<string>\"\n          ]\n        },\n        \"conversionRate\": \"<number>\",\n        \"totalBudget\": \"<number>\"\n      },\n      \"version\": \"<integer>\",\n      \"commentCount\": \"<integer>\",\n      \"createdAt\": \"<dateTime>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"withdrawalDetails\": {\n        \"category\": \"Policy violation\",\n        \"userId\": \"<string>\",\n        \"date\": \"<dateTime>\",\n        \"comment\": \"<string>\"\n      },\n      \"submittedAt\": \"<dateTime>\"\n    }\n  ],\n  \"meta\": {\n    \"page\": \"<integer>\",\n    \"limit\": \"<integer>\",\n    \"total\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"hasNextPage\": \"<boolean>\",\n    \"hasPreviousPage\": \"<boolean>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1dfa450e-26a2-49c0-bfb2-919059947e6a",
+                            "id": "8e181ae7-1d5f-4ac7-9ddb-b6be04dfef96",
                             "name": "Invalid request. Possible reasons: missing vote parameter, invalid query parameters, unauthorized draft access.",
                             "originalRequest": {
                                 "url": {
@@ -1879,7 +1879,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "vote",
-                                            "value": "C5FE5fdDbc2D74a71b70cf3B"
+                                            "value": "d1D36d221Aeba96D14Ed2acd"
                                         },
                                         {
                                             "disabled": false,
@@ -1973,12 +1973,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2c3a2443-f849-4cff-86d1-0ba60a5d4eb5",
+                            "id": "d01b82f8-7da9-488b-ad6d-d6e4faf69ba6",
                             "name": "Vote cycle not found.",
                             "originalRequest": {
                                 "url": {
@@ -1996,7 +1996,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "vote",
-                                            "value": "C5FE5fdDbc2D74a71b70cf3B"
+                                            "value": "d1D36d221Aeba96D14Ed2acd"
                                         },
                                         {
                                             "disabled": false,
@@ -2090,7 +2090,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -2105,7 +2105,7 @@
                     "description": "",
                     "item": [
                         {
-                            "id": "878cdab4-9779-435b-8ac4-14be830fad4a",
+                            "id": "cd4746b0-8d3a-4d1d-bce8-dcd0442ec31a",
                             "name": "Get a proposal",
                             "request": {
                                 "name": "Get a proposal",
@@ -2125,7 +2125,7 @@
                                     "variable": [
                                         {
                                             "type": "any",
-                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                             "key": "proposalId",
                                             "disabled": false,
                                             "description": {
@@ -2163,7 +2163,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "1a0fcf81-bcba-4796-a0a4-3e68205cb2b6",
+                                    "id": "7f79be87-d5a8-4191-8f00-027c22fc48ba",
                                     "name": "Proposal found.",
                                     "originalRequest": {
                                         "url": {
@@ -2183,7 +2183,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "proposalId"
                                                 }
                                             ]
@@ -2213,12 +2213,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"_id\": \"<string>\",\n  \"proposerId\": \"<string>\",\n  \"voteId\": \"<string>\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"archived\",\n  \"metaData\": {},\n  \"version\": \"<integer>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"withdrawalDetails\": {\n    \"category\": \"Duplicate submission\",\n    \"userId\": \"<string>\",\n    \"date\": \"<dateTime>\",\n    \"comment\": \"<string>\"\n  },\n  \"versions\": [\n    {\n      \"_id\": \"<string>\",\n      \"createdAt\": \"<dateTime>\"\n    },\n    {\n      \"_id\": \"<string>\",\n      \"createdAt\": \"<dateTime>\"\n    }\n  ],\n  \"currentProposalId\": \"<string>\",\n  \"submittedAt\": \"<dateTime>\",\n  \"treasuryDonationTxHash\": \"<string>\",\n  \"commentCount\": \"<integer>\"\n}",
+                                    "body": "{\n  \"_id\": \"<string>\",\n  \"proposerId\": \"<string>\",\n  \"voteId\": \"<string>\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"withdrawnByProposer\",\n  \"metaData\": {},\n  \"version\": \"<integer>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"withdrawalDetails\": {\n    \"category\": \"Inappropriate content\",\n    \"userId\": \"<string>\",\n    \"date\": \"<dateTime>\",\n    \"comment\": \"<string>\"\n  },\n  \"versions\": [\n    {\n      \"_id\": \"<string>\",\n      \"createdAt\": \"<dateTime>\"\n    },\n    {\n      \"_id\": \"<string>\",\n      \"createdAt\": \"<dateTime>\"\n    }\n  ],\n  \"currentProposalId\": \"<string>\",\n  \"submittedAt\": \"<dateTime>\",\n  \"treasuryDonationTxHash\": \"<string>\",\n  \"commentCount\": \"<integer>\"\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "df1134ce-9ed0-41df-9545-7cc323fef451",
+                                    "id": "c207c8c1-67a9-402f-b538-4e497166f0de",
                                     "name": "Invalid proposal ID format.",
                                     "originalRequest": {
                                         "url": {
@@ -2238,7 +2238,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "proposalId"
                                                 }
                                             ]
@@ -2268,12 +2268,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "008e95d7-9aea-4276-9559-bce79ec724a5",
+                                    "id": "ba685707-4c24-46cd-830f-be82cbb2bfc0",
                                     "name": "Forbidden. Draft proposal is not accessible without proper authorization.",
                                     "originalRequest": {
                                         "url": {
@@ -2293,7 +2293,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "proposalId"
                                                 }
                                             ]
@@ -2323,12 +2323,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "7a70d788-b507-4011-9153-1eae30a4b472",
+                                    "id": "14f48a63-37c7-4036-8d33-83c354117970",
                                     "name": "Proposal not found.",
                                     "originalRequest": {
                                         "url": {
@@ -2348,7 +2348,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "proposalId"
                                                 }
                                             ]
@@ -2378,7 +2378,7 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 }
@@ -2389,7 +2389,7 @@
                             }
                         },
                         {
-                            "id": "ef745c23-db86-4ee0-943b-f98a74b68c8d",
+                            "id": "03ef8e18-639b-44f8-8f24-c3b3de23f05a",
                             "name": "Update a proposal",
                             "request": {
                                 "name": "Update a proposal",
@@ -2409,7 +2409,7 @@
                                     "variable": [
                                         {
                                             "type": "any",
-                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                             "key": "proposalId",
                                             "disabled": false,
                                             "description": {
@@ -2432,7 +2432,7 @@
                                 "method": "PUT",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"voteId\": \"4B7a4Aa0d23cf4B5B84E7CEb\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"live\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
+                                    "raw": "{\n  \"voteId\": \"1C9bDcdEf4EBfDF47B24e8CB\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2460,7 +2460,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "0d03b581-31dd-41eb-b0cb-2cddca0bd37d",
+                                    "id": "e1a67ad4-1bf4-4cb5-8327-f96ae56b628e",
                                     "name": "Proposal updated successfully.",
                                     "originalRequest": {
                                         "url": {
@@ -2480,7 +2480,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "proposalId"
                                                 }
                                             ]
@@ -2506,7 +2506,7 @@
                                         "method": "PUT",
                                         "body": {
                                             "mode": "raw",
-                                            "raw": "{\n  \"voteId\": \"4B7a4Aa0d23cf4B5B84E7CEb\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"live\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
+                                            "raw": "{\n  \"voteId\": \"1C9bDcdEf4EBfDF47B24e8CB\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
                                             "options": {
                                                 "raw": {
                                                     "headerFamily": "json",
@@ -2523,12 +2523,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"_id\": \"<string>\",\n  \"proposerId\": \"<string>\",\n  \"voteId\": \"<string>\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"live\",\n  \"metaData\": {},\n  \"version\": \"<integer>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"withdrawalDetails\": {\n    \"category\": \"Spam\",\n    \"userId\": \"<string>\",\n    \"date\": \"<dateTime>\",\n    \"comment\": \"<string>\"\n  },\n  \"versions\": [\n    {\n      \"_id\": \"<string>\",\n      \"createdAt\": \"<dateTime>\"\n    },\n    {\n      \"_id\": \"<string>\",\n      \"createdAt\": \"<dateTime>\"\n    }\n  ],\n  \"currentProposalId\": \"<string>\",\n  \"submittedAt\": \"<dateTime>\",\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
+                                    "body": "{\n  \"_id\": \"<string>\",\n  \"proposerId\": \"<string>\",\n  \"voteId\": \"<string>\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"version\": \"<integer>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"withdrawalDetails\": {\n    \"category\": \"Duplicate submission\",\n    \"userId\": \"<string>\",\n    \"date\": \"<dateTime>\",\n    \"comment\": \"<string>\"\n  },\n  \"versions\": [\n    {\n      \"_id\": \"<string>\",\n      \"createdAt\": \"<dateTime>\"\n    },\n    {\n      \"_id\": \"<string>\",\n      \"createdAt\": \"<dateTime>\"\n    }\n  ],\n  \"currentProposalId\": \"<string>\",\n  \"submittedAt\": \"<dateTime>\",\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "29180150-8c6e-4028-8c4b-5f8c5aa6ae70",
+                                    "id": "3be68b1f-c984-4dc3-b078-a117b29c1358",
                                     "name": "Invalid request. Possible reasons: validation errors, proposal is archived, attempted status change on live proposal, update locked after reviewEndDate.",
                                     "originalRequest": {
                                         "url": {
@@ -2548,7 +2548,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "proposalId"
                                                 }
                                             ]
@@ -2574,7 +2574,7 @@
                                         "method": "PUT",
                                         "body": {
                                             "mode": "raw",
-                                            "raw": "{\n  \"voteId\": \"4B7a4Aa0d23cf4B5B84E7CEb\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"live\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
+                                            "raw": "{\n  \"voteId\": \"1C9bDcdEf4EBfDF47B24e8CB\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
                                             "options": {
                                                 "raw": {
                                                     "headerFamily": "json",
@@ -2591,12 +2591,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "84ae1bb3-0612-4718-ba71-9a43686f0a9c",
+                                    "id": "38021bbd-edd3-4529-8dde-3da3dc456f49",
                                     "name": "Not authenticated.",
                                     "originalRequest": {
                                         "url": {
@@ -2616,7 +2616,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "proposalId"
                                                 }
                                             ]
@@ -2642,7 +2642,7 @@
                                         "method": "PUT",
                                         "body": {
                                             "mode": "raw",
-                                            "raw": "{\n  \"voteId\": \"4B7a4Aa0d23cf4B5B84E7CEb\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"live\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
+                                            "raw": "{\n  \"voteId\": \"1C9bDcdEf4EBfDF47B24e8CB\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
                                             "options": {
                                                 "raw": {
                                                     "headerFamily": "json",
@@ -2659,12 +2659,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "036f3f46-4364-422c-a5bb-9a1f9a3138b8",
+                                    "id": "54cb95f4-870d-484a-9de8-7a3023fe499c",
                                     "name": "Forbidden. Only the original proposer may update.",
                                     "originalRequest": {
                                         "url": {
@@ -2684,7 +2684,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "proposalId"
                                                 }
                                             ]
@@ -2710,7 +2710,7 @@
                                         "method": "PUT",
                                         "body": {
                                             "mode": "raw",
-                                            "raw": "{\n  \"voteId\": \"4B7a4Aa0d23cf4B5B84E7CEb\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"live\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
+                                            "raw": "{\n  \"voteId\": \"1C9bDcdEf4EBfDF47B24e8CB\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
                                             "options": {
                                                 "raw": {
                                                     "headerFamily": "json",
@@ -2727,12 +2727,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "a9bca5a3-c4d8-43f9-ab80-cf724f8f327b",
+                                    "id": "4511d490-a48f-4664-9bd3-f4a1bad14e5e",
                                     "name": "Proposal not found.",
                                     "originalRequest": {
                                         "url": {
@@ -2752,7 +2752,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "proposalId"
                                                 }
                                             ]
@@ -2778,7 +2778,7 @@
                                         "method": "PUT",
                                         "body": {
                                             "mode": "raw",
-                                            "raw": "{\n  \"voteId\": \"4B7a4Aa0d23cf4B5B84E7CEb\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"live\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
+                                            "raw": "{\n  \"voteId\": \"1C9bDcdEf4EBfDF47B24e8CB\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
                                             "options": {
                                                 "raw": {
                                                     "headerFamily": "json",
@@ -2795,12 +2795,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "cd286009-e231-4cee-9a4b-a26bdbdfa4bf",
+                                    "id": "49312b99-4cfe-42ec-874d-fb03aee913e5",
                                     "name": "Rate limit exceeded (10 requests per minute per user).",
                                     "originalRequest": {
                                         "url": {
@@ -2820,7 +2820,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "proposalId"
                                                 }
                                             ]
@@ -2846,7 +2846,7 @@
                                         "method": "PUT",
                                         "body": {
                                             "mode": "raw",
-                                            "raw": "{\n  \"voteId\": \"4B7a4Aa0d23cf4B5B84E7CEb\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"live\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
+                                            "raw": "{\n  \"voteId\": \"1C9bDcdEf4EBfDF47B24e8CB\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"draft\",\n  \"metaData\": {},\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
                                             "options": {
                                                 "raw": {
                                                     "headerFamily": "json",
@@ -2863,7 +2863,7 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 }
@@ -2874,7 +2874,7 @@
                             }
                         },
                         {
-                            "id": "58d179b8-0e09-4867-9523-d0714d87157a",
+                            "id": "8dd57e37-db49-4754-a8ea-1c08c48964ac",
                             "name": "Delete a draft proposal",
                             "request": {
                                 "name": "Delete a draft proposal",
@@ -2894,7 +2894,7 @@
                                     "variable": [
                                         {
                                             "type": "any",
-                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                             "key": "proposalId",
                                             "disabled": false,
                                             "description": {
@@ -2932,7 +2932,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "cddc0751-9227-4ca5-acdd-801424fa832d",
+                                    "id": "b61e1f64-c808-48ab-b9b6-a0e2b59bacb4",
                                     "name": "Proposal deleted successfully.",
                                     "originalRequest": {
                                         "url": {
@@ -2952,7 +2952,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "proposalId"
                                                 }
                                             ]
@@ -2987,7 +2987,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "77405156-493e-4062-86f7-0c7f71c9f5c9",
+                                    "id": "dcc15dde-fe30-4586-a397-5b2a7f1f338e",
                                     "name": "Invalid request. The proposal is not in draft status.",
                                     "originalRequest": {
                                         "url": {
@@ -3007,7 +3007,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "proposalId"
                                                 }
                                             ]
@@ -3037,12 +3037,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "cc2cf81b-eeb9-4f97-a4df-677d8f3d5c89",
+                                    "id": "e03be279-be89-4093-9a9a-053a1264a628",
                                     "name": "Not authenticated.",
                                     "originalRequest": {
                                         "url": {
@@ -3062,7 +3062,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "proposalId"
                                                 }
                                             ]
@@ -3092,12 +3092,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "67336a09-412d-4292-87da-71f711d8eb42",
+                                    "id": "1aa749d9-685a-42d9-a1eb-2d44e7bc49d6",
                                     "name": "Forbidden. Only the original proposer may delete.",
                                     "originalRequest": {
                                         "url": {
@@ -3117,7 +3117,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "proposalId"
                                                 }
                                             ]
@@ -3147,12 +3147,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "fe6a67b2-c03d-4fde-9b39-26663a3b00c0",
+                                    "id": "6f428fd3-1cc2-4a27-bf95-81d7030cb2b3",
                                     "name": "Proposal not found.",
                                     "originalRequest": {
                                         "url": {
@@ -3172,7 +3172,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "proposalId"
                                                 }
                                             ]
@@ -3202,12 +3202,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "a072d1d0-4d68-4813-bb35-706b72b62258",
+                                    "id": "3f4da4aa-54ad-42d4-8b63-154803d668c5",
                                     "name": "Rate limit exceeded (10 requests per minute per user).",
                                     "originalRequest": {
                                         "url": {
@@ -3227,7 +3227,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "proposalId"
                                                 }
                                             ]
@@ -3257,7 +3257,7 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 }
@@ -3272,7 +3272,7 @@
                             "description": "",
                             "item": [
                                 {
-                                    "id": "f1c8e368-79ca-4da0-b1df-380a7562c7ac",
+                                    "id": "b8d8a97e-ec0c-4738-8beb-530ba8b9d5c0",
                                     "name": "Withdraw a proposal",
                                     "request": {
                                         "name": "Withdraw a proposal",
@@ -3293,7 +3293,7 @@
                                             "variable": [
                                                 {
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "proposalId",
                                                     "disabled": false,
                                                     "description": {
@@ -3316,7 +3316,7 @@
                                         "method": "PUT",
                                         "body": {
                                             "mode": "raw",
-                                            "raw": "{\n  \"category\": \"Inappropriate content\",\n  \"comment\": \"<string>\"\n}",
+                                            "raw": "{\n  \"category\": \"Other\",\n  \"comment\": \"<string>\"\n}",
                                             "options": {
                                                 "raw": {
                                                     "headerFamily": "json",
@@ -3344,7 +3344,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "258cd937-9e6b-4599-b5fc-5df667e25901",
+                                            "id": "7ab34599-c71f-4479-826d-d7fae84c03c2",
                                             "name": "Proposal withdrawn successfully.",
                                             "originalRequest": {
                                                 "url": {
@@ -3365,7 +3365,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "proposalId"
                                                         }
                                                     ]
@@ -3391,7 +3391,7 @@
                                                 "method": "PUT",
                                                 "body": {
                                                     "mode": "raw",
-                                                    "raw": "{\n  \"category\": \"Inappropriate content\",\n  \"comment\": \"<string>\"\n}",
+                                                    "raw": "{\n  \"category\": \"Other\",\n  \"comment\": \"<string>\"\n}",
                                                     "options": {
                                                         "raw": {
                                                             "headerFamily": "json",
@@ -3408,12 +3408,12 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n  \"_id\": \"<string>\",\n  \"proposerId\": \"<string>\",\n  \"voteId\": \"<string>\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"withdrawnByAdmin\",\n  \"metaData\": {},\n  \"version\": \"<integer>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"withdrawalDetails\": {\n    \"category\": \"Policy violation\",\n    \"userId\": \"<string>\",\n    \"date\": \"<dateTime>\",\n    \"comment\": \"<string>\"\n  },\n  \"versions\": [\n    {\n      \"_id\": \"<string>\",\n      \"createdAt\": \"<dateTime>\"\n    },\n    {\n      \"_id\": \"<string>\",\n      \"createdAt\": \"<dateTime>\"\n    }\n  ],\n  \"currentProposalId\": \"<string>\",\n  \"submittedAt\": \"<dateTime>\",\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
+                                            "body": "{\n  \"_id\": \"<string>\",\n  \"proposerId\": \"<string>\",\n  \"voteId\": \"<string>\",\n  \"title\": \"<string>\",\n  \"summary\": \"<string>\",\n  \"status\": \"withdrawnByAdmin\",\n  \"metaData\": {},\n  \"version\": \"<integer>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"withdrawalDetails\": {\n    \"category\": \"Duplicate submission\",\n    \"userId\": \"<string>\",\n    \"date\": \"<dateTime>\",\n    \"comment\": \"<string>\"\n  },\n  \"versions\": [\n    {\n      \"_id\": \"<string>\",\n      \"createdAt\": \"<dateTime>\"\n    },\n    {\n      \"_id\": \"<string>\",\n      \"createdAt\": \"<dateTime>\"\n    }\n  ],\n  \"currentProposalId\": \"<string>\",\n  \"submittedAt\": \"<dateTime>\",\n  \"treasuryDonationTxHash\": \"<string>\"\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "4c81d3c5-10cb-40c1-b6d2-58a2ca5d8f99",
+                                            "id": "56acd948-89ea-41e9-a820-fdc1e0e41e53",
                                             "name": "Invalid request. Possible reasons: proposal is not live, invalid withdrawal category, past the allowed withdrawal deadline.",
                                             "originalRequest": {
                                                 "url": {
@@ -3434,7 +3434,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "proposalId"
                                                         }
                                                     ]
@@ -3460,7 +3460,7 @@
                                                 "method": "PUT",
                                                 "body": {
                                                     "mode": "raw",
-                                                    "raw": "{\n  \"category\": \"Inappropriate content\",\n  \"comment\": \"<string>\"\n}",
+                                                    "raw": "{\n  \"category\": \"Other\",\n  \"comment\": \"<string>\"\n}",
                                                     "options": {
                                                         "raw": {
                                                             "headerFamily": "json",
@@ -3477,12 +3477,12 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "0af05134-1e6d-45d9-8c22-f640b3554825",
+                                            "id": "0f4f1457-6720-41d7-b56b-56d33f393547",
                                             "name": "Not authenticated.",
                                             "originalRequest": {
                                                 "url": {
@@ -3503,7 +3503,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "proposalId"
                                                         }
                                                     ]
@@ -3529,7 +3529,7 @@
                                                 "method": "PUT",
                                                 "body": {
                                                     "mode": "raw",
-                                                    "raw": "{\n  \"category\": \"Inappropriate content\",\n  \"comment\": \"<string>\"\n}",
+                                                    "raw": "{\n  \"category\": \"Other\",\n  \"comment\": \"<string>\"\n}",
                                                     "options": {
                                                         "raw": {
                                                             "headerFamily": "json",
@@ -3546,12 +3546,12 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "c20f285c-6379-4957-92a1-d826abaecd7e",
+                                            "id": "7e94ddba-dcaa-4a9f-a2e0-e33ba22cebf0",
                                             "name": "Forbidden. The requester is neither the proposer nor a vote cycle admin, or the withdrawal deadline has passed for the requester's role.",
                                             "originalRequest": {
                                                 "url": {
@@ -3572,7 +3572,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "proposalId"
                                                         }
                                                     ]
@@ -3598,7 +3598,7 @@
                                                 "method": "PUT",
                                                 "body": {
                                                     "mode": "raw",
-                                                    "raw": "{\n  \"category\": \"Inappropriate content\",\n  \"comment\": \"<string>\"\n}",
+                                                    "raw": "{\n  \"category\": \"Other\",\n  \"comment\": \"<string>\"\n}",
                                                     "options": {
                                                         "raw": {
                                                             "headerFamily": "json",
@@ -3615,12 +3615,12 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "30e2b6cb-76e6-4235-bd71-0f1fee59151b",
+                                            "id": "138c2e4b-6e7a-4e7a-8926-fb3dc6437957",
                                             "name": "Proposal not found.",
                                             "originalRequest": {
                                                 "url": {
@@ -3641,7 +3641,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "proposalId"
                                                         }
                                                     ]
@@ -3667,7 +3667,7 @@
                                                 "method": "PUT",
                                                 "body": {
                                                     "mode": "raw",
-                                                    "raw": "{\n  \"category\": \"Inappropriate content\",\n  \"comment\": \"<string>\"\n}",
+                                                    "raw": "{\n  \"category\": \"Other\",\n  \"comment\": \"<string>\"\n}",
                                                     "options": {
                                                         "raw": {
                                                             "headerFamily": "json",
@@ -3684,12 +3684,12 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "6df6aaf8-f8f0-4f0e-a0ad-0fc0037ec9d8",
+                                            "id": "ee844868-aa5d-4a98-af1e-9ea0ebb83ac0",
                                             "name": "Rate limit exceeded (10 requests per minute per user).",
                                             "originalRequest": {
                                                 "url": {
@@ -3710,7 +3710,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "proposalId"
                                                         }
                                                     ]
@@ -3736,7 +3736,7 @@
                                                 "method": "PUT",
                                                 "body": {
                                                     "mode": "raw",
-                                                    "raw": "{\n  \"category\": \"Inappropriate content\",\n  \"comment\": \"<string>\"\n}",
+                                                    "raw": "{\n  \"category\": \"Other\",\n  \"comment\": \"<string>\"\n}",
                                                     "options": {
                                                         "raw": {
                                                             "headerFamily": "json",
@@ -3753,7 +3753,7 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         }
@@ -3774,7 +3774,7 @@
             "description": "",
             "item": [
                 {
-                    "id": "bc709374-771e-4ea2-88cd-bb20373ebc1f",
+                    "id": "3205f1af-38d1-4969-9f5b-08bbd9c3d8cd",
                     "name": "List top-level comments",
                     "request": {
                         "name": "List top-level comments",
@@ -3797,7 +3797,7 @@
                                         "type": "text/plain"
                                     },
                                     "key": "proposal",
-                                    "value": "C5FE5fdDbc2D74a71b70cf3B"
+                                    "value": "d1D36d221Aeba96D14Ed2acd"
                                 },
                                 {
                                     "disabled": false,
@@ -3806,7 +3806,7 @@
                                         "type": "text/plain"
                                     },
                                     "key": "status",
-                                    "value": "withdrawnByAdmin"
+                                    "value": "withdrawn"
                                 },
                                 {
                                     "disabled": false,
@@ -3829,7 +3829,7 @@
                                 {
                                     "disabled": false,
                                     "description": {
-                                        "content": "Filter by author type. Accepts a comma-separated list of types.\n",
+                                        "content": "Filter by author type. Accepts a comma-separated list of types (e.g. `proposer,admin,drep,user`). A top-level comment is returned when either the comment author matches the filter OR any reply within the same thread is by a matching author — this preserves replies-to-admin / replies-to-proposer visibility in filtered views.\n",
                                         "type": "text/plain"
                                     },
                                     "key": "userType",
@@ -3868,7 +3868,7 @@
                     },
                     "response": [
                         {
-                            "id": "c3ba6d63-70bf-4d19-b0d9-d367f16fed05",
+                            "id": "97eb5b06-5644-4df4-af68-0cf0581ffe71",
                             "name": "Paginated list of comments.",
                             "originalRequest": {
                                 "url": {
@@ -3886,7 +3886,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "proposal",
-                                            "value": "C5FE5fdDbc2D74a71b70cf3B"
+                                            "value": "d1D36d221Aeba96D14Ed2acd"
                                         },
                                         {
                                             "disabled": false,
@@ -3895,7 +3895,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "status",
-                                            "value": "withdrawnByAdmin"
+                                            "value": "withdrawn"
                                         },
                                         {
                                             "disabled": false,
@@ -3918,7 +3918,7 @@
                                         {
                                             "disabled": false,
                                             "description": {
-                                                "content": "Filter by author type. Accepts a comma-separated list of types.\n",
+                                                "content": "Filter by author type. Accepts a comma-separated list of types (e.g. `proposer,admin,drep,user`). A top-level comment is returned when either the comment author matches the filter OR any reply within the same thread is by a matching author — this preserves replies-to-admin / replies-to-proposer visibility in filtered views.\n",
                                                 "type": "text/plain"
                                             },
                                             "key": "userType",
@@ -3962,12 +3962,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"data\": [\n    {\n      \"_id\": \"<string>\",\n      \"content\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"replyCount\": \"<integer>\",\n      \"likeCount\": \"<integer>\",\n      \"author\": {\n        \"_id\": \"<string>\",\n        \"type\": \"user\",\n        \"name\": \"<string>\"\n      },\n      \"parentId\": \"<string>\",\n      \"userLiked\": \"<boolean>\",\n      \"withdrawalDetails\": {\n        \"category\": \"Inappropriate content\",\n        \"userId\": \"<string>\",\n        \"date\": \"<dateTime>\",\n        \"comment\": \"<string>\"\n      }\n    },\n    {\n      \"_id\": \"<string>\",\n      \"content\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"replyCount\": \"<integer>\",\n      \"likeCount\": \"<integer>\",\n      \"author\": {\n        \"_id\": \"<string>\",\n        \"type\": \"proposer\",\n        \"name\": \"<string>\"\n      },\n      \"parentId\": \"<string>\",\n      \"userLiked\": \"<boolean>\",\n      \"withdrawalDetails\": {\n        \"category\": \"Spam\",\n        \"userId\": \"<string>\",\n        \"date\": \"<dateTime>\",\n        \"comment\": \"<string>\"\n      }\n    }\n  ],\n  \"meta\": {\n    \"page\": \"<integer>\",\n    \"limit\": \"<integer>\",\n    \"total\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"hasNextPage\": \"<boolean>\",\n    \"hasPreviousPage\": \"<boolean>\"\n  }\n}",
+                            "body": "{\n  \"data\": [\n    {\n      \"_id\": \"<string>\",\n      \"content\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"replyCount\": \"<integer>\",\n      \"likeCount\": \"<integer>\",\n      \"author\": {\n        \"_id\": \"<string>\",\n        \"type\": \"admin\",\n        \"name\": \"<string>\"\n      },\n      \"parentId\": \"<string>\",\n      \"userLiked\": \"<boolean>\",\n      \"withdrawalDetails\": {\n        \"category\": \"Policy violation\",\n        \"userId\": \"<string>\",\n        \"date\": \"<dateTime>\",\n        \"comment\": \"<string>\"\n      }\n    },\n    {\n      \"_id\": \"<string>\",\n      \"content\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"replyCount\": \"<integer>\",\n      \"likeCount\": \"<integer>\",\n      \"author\": {\n        \"_id\": \"<string>\",\n        \"type\": \"drep\",\n        \"name\": \"<string>\"\n      },\n      \"parentId\": \"<string>\",\n      \"userLiked\": \"<boolean>\",\n      \"withdrawalDetails\": {\n        \"category\": \"Policy violation\",\n        \"userId\": \"<string>\",\n        \"date\": \"<dateTime>\",\n        \"comment\": \"<string>\"\n      }\n    }\n  ],\n  \"meta\": {\n    \"page\": \"<integer>\",\n    \"limit\": \"<integer>\",\n    \"total\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"hasNextPage\": \"<boolean>\",\n    \"hasPreviousPage\": \"<boolean>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "f92cbb84-284a-46f2-b888-adfb2c4909ba",
+                            "id": "63c73214-1708-4246-977a-a3ec6e29cd67",
                             "name": "Invalid request. Possible reasons: missing proposal parameter, invalid query parameters, non-admin attempting to filter by non-live status.",
                             "originalRequest": {
                                 "url": {
@@ -3985,7 +3985,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "proposal",
-                                            "value": "C5FE5fdDbc2D74a71b70cf3B"
+                                            "value": "d1D36d221Aeba96D14Ed2acd"
                                         },
                                         {
                                             "disabled": false,
@@ -3994,7 +3994,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "status",
-                                            "value": "withdrawnByAdmin"
+                                            "value": "withdrawn"
                                         },
                                         {
                                             "disabled": false,
@@ -4017,7 +4017,7 @@
                                         {
                                             "disabled": false,
                                             "description": {
-                                                "content": "Filter by author type. Accepts a comma-separated list of types.\n",
+                                                "content": "Filter by author type. Accepts a comma-separated list of types (e.g. `proposer,admin,drep,user`). A top-level comment is returned when either the comment author matches the filter OR any reply within the same thread is by a matching author — this preserves replies-to-admin / replies-to-proposer visibility in filtered views.\n",
                                                 "type": "text/plain"
                                             },
                                             "key": "userType",
@@ -4061,12 +4061,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ce958f34-9b54-4841-bb37-2793f1ae4c34",
+                            "id": "9ae5e86c-1862-45cd-9ff4-a85fa38511f7",
                             "name": "Proposal not found.",
                             "originalRequest": {
                                 "url": {
@@ -4084,7 +4084,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "proposal",
-                                            "value": "C5FE5fdDbc2D74a71b70cf3B"
+                                            "value": "d1D36d221Aeba96D14Ed2acd"
                                         },
                                         {
                                             "disabled": false,
@@ -4093,7 +4093,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "status",
-                                            "value": "withdrawnByAdmin"
+                                            "value": "withdrawn"
                                         },
                                         {
                                             "disabled": false,
@@ -4116,7 +4116,7 @@
                                         {
                                             "disabled": false,
                                             "description": {
-                                                "content": "Filter by author type. Accepts a comma-separated list of types.\n",
+                                                "content": "Filter by author type. Accepts a comma-separated list of types (e.g. `proposer,admin,drep,user`). A top-level comment is returned when either the comment author matches the filter OR any reply within the same thread is by a matching author — this preserves replies-to-admin / replies-to-proposer visibility in filtered views.\n",
                                                 "type": "text/plain"
                                             },
                                             "key": "userType",
@@ -4160,7 +4160,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -4171,7 +4171,7 @@
                     }
                 },
                 {
-                    "id": "f839089b-f75f-42d9-a2b1-065bbf85619f",
+                    "id": "836e90d6-81e9-4445-bddb-ffe4ccfb5baa",
                     "name": "Create a comment",
                     "request": {
                         "name": "Create a comment",
@@ -4202,7 +4202,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"proposalId\": \"AfCab4f2132B04DD1d7f8BAa\",\n  \"content\": \"<string>\",\n  \"parentId\": \"bdCCC3be6e4BbE1a672da2cD\"\n}",
+                            "raw": "{\n  \"proposalId\": \"9fBcC7cd770e76130e2afDB1\",\n  \"content\": \"<string>\",\n  \"parentId\": \"4dBF29D3312e2dEDa05A28bf\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -4230,7 +4230,7 @@
                     },
                     "response": [
                         {
-                            "id": "c6bd0f38-1e77-49d0-b720-d9ba54ab274a",
+                            "id": "eb034a67-b292-438b-945d-dc9bf0c4bf82",
                             "name": "Comment created successfully.",
                             "originalRequest": {
                                 "url": {
@@ -4264,7 +4264,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"proposalId\": \"AfCab4f2132B04DD1d7f8BAa\",\n  \"content\": \"<string>\",\n  \"parentId\": \"bdCCC3be6e4BbE1a672da2cD\"\n}",
+                                    "raw": "{\n  \"proposalId\": \"9fBcC7cd770e76130e2afDB1\",\n  \"content\": \"<string>\",\n  \"parentId\": \"4dBF29D3312e2dEDa05A28bf\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4281,12 +4281,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"_id\": \"<string>\",\n  \"content\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"replyCount\": \"<integer>\",\n  \"likeCount\": \"<integer>\",\n  \"author\": {\n    \"_id\": \"<string>\",\n    \"type\": \"drep\",\n    \"name\": \"<string>\"\n  },\n  \"parentId\": \"<string>\",\n  \"userLiked\": \"<boolean>\",\n  \"withdrawalDetails\": {\n    \"category\": \"Inappropriate content\",\n    \"userId\": \"<string>\",\n    \"date\": \"<dateTime>\",\n    \"comment\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"_id\": \"<string>\",\n  \"content\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"replyCount\": \"<integer>\",\n  \"likeCount\": \"<integer>\",\n  \"author\": {\n    \"_id\": \"<string>\",\n    \"type\": \"user\",\n    \"name\": \"<string>\"\n  },\n  \"parentId\": \"<string>\",\n  \"userLiked\": \"<boolean>\",\n  \"withdrawalDetails\": {\n    \"category\": \"Duplicate submission\",\n    \"userId\": \"<string>\",\n    \"date\": \"<dateTime>\",\n    \"comment\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e5626617-382a-4646-a3ec-093ff454bfc1",
+                            "id": "55bcc9f7-961d-49e8-85ad-893a353bd2b2",
                             "name": "Invalid request. Possible reasons: missing required fields, content exceeds 2000 characters, proposal is not live, past feedbackEndDate, duplicate comment, replying to a withdrawn comment.",
                             "originalRequest": {
                                 "url": {
@@ -4320,7 +4320,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"proposalId\": \"AfCab4f2132B04DD1d7f8BAa\",\n  \"content\": \"<string>\",\n  \"parentId\": \"bdCCC3be6e4BbE1a672da2cD\"\n}",
+                                    "raw": "{\n  \"proposalId\": \"9fBcC7cd770e76130e2afDB1\",\n  \"content\": \"<string>\",\n  \"parentId\": \"4dBF29D3312e2dEDa05A28bf\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4337,12 +4337,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "15f38e2d-4571-4e29-be87-b320828980bf",
+                            "id": "443c4c9a-8107-49b9-b451-18f4cb91b72c",
                             "name": "Not authenticated.",
                             "originalRequest": {
                                 "url": {
@@ -4376,7 +4376,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"proposalId\": \"AfCab4f2132B04DD1d7f8BAa\",\n  \"content\": \"<string>\",\n  \"parentId\": \"bdCCC3be6e4BbE1a672da2cD\"\n}",
+                                    "raw": "{\n  \"proposalId\": \"9fBcC7cd770e76130e2afDB1\",\n  \"content\": \"<string>\",\n  \"parentId\": \"4dBF29D3312e2dEDa05A28bf\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4393,12 +4393,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5365fcb8-5fd8-4b64-8191-b6898dd6684b",
+                            "id": "7d963f4a-82fa-4c2e-a2c5-9b7f1d59a4fd",
                             "name": "Proposal or parent comment not found.",
                             "originalRequest": {
                                 "url": {
@@ -4432,7 +4432,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"proposalId\": \"AfCab4f2132B04DD1d7f8BAa\",\n  \"content\": \"<string>\",\n  \"parentId\": \"bdCCC3be6e4BbE1a672da2cD\"\n}",
+                                    "raw": "{\n  \"proposalId\": \"9fBcC7cd770e76130e2afDB1\",\n  \"content\": \"<string>\",\n  \"parentId\": \"4dBF29D3312e2dEDa05A28bf\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4449,12 +4449,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "29ccf1a0-03b2-4d92-9fa1-7d4c48b75e20",
+                            "id": "e944de4d-ed91-4b7a-be31-0ae87de07d96",
                             "name": "Rate limit exceeded (5 per minute or 20 per hour per user).",
                             "originalRequest": {
                                 "url": {
@@ -4488,7 +4488,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"proposalId\": \"AfCab4f2132B04DD1d7f8BAa\",\n  \"content\": \"<string>\",\n  \"parentId\": \"bdCCC3be6e4BbE1a672da2cD\"\n}",
+                                    "raw": "{\n  \"proposalId\": \"9fBcC7cd770e76130e2afDB1\",\n  \"content\": \"<string>\",\n  \"parentId\": \"4dBF29D3312e2dEDa05A28bf\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4505,7 +4505,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -4520,7 +4520,7 @@
                     "description": "",
                     "item": [
                         {
-                            "id": "0b348712-d5ae-4744-8e00-09d46cf36633",
+                            "id": "97161e9e-beef-46b9-b5e0-2355094ea93e",
                             "name": "Get a single comment",
                             "request": {
                                 "name": "Get a single comment",
@@ -4540,7 +4540,7 @@
                                     "variable": [
                                         {
                                             "type": "any",
-                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                             "key": "commentId",
                                             "disabled": false,
                                             "description": {
@@ -4578,7 +4578,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "3e4e317a-a27d-4564-a275-6c83ca765c6b",
+                                    "id": "813fa8e2-8aa8-42ee-8fbd-72660d3d0240",
                                     "name": "Comment found.",
                                     "originalRequest": {
                                         "url": {
@@ -4598,7 +4598,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "commentId"
                                                 }
                                             ]
@@ -4628,12 +4628,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"_id\": \"<string>\",\n  \"content\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"replyCount\": \"<integer>\",\n  \"likeCount\": \"<integer>\",\n  \"author\": {\n    \"_id\": \"<string>\",\n    \"type\": \"drep\",\n    \"name\": \"<string>\"\n  },\n  \"parentId\": \"<string>\",\n  \"userLiked\": \"<boolean>\",\n  \"withdrawalDetails\": {\n    \"category\": \"Inappropriate content\",\n    \"userId\": \"<string>\",\n    \"date\": \"<dateTime>\",\n    \"comment\": \"<string>\"\n  }\n}",
+                                    "body": "{\n  \"_id\": \"<string>\",\n  \"content\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"replyCount\": \"<integer>\",\n  \"likeCount\": \"<integer>\",\n  \"author\": {\n    \"_id\": \"<string>\",\n    \"type\": \"user\",\n    \"name\": \"<string>\"\n  },\n  \"parentId\": \"<string>\",\n  \"userLiked\": \"<boolean>\",\n  \"withdrawalDetails\": {\n    \"category\": \"Duplicate submission\",\n    \"userId\": \"<string>\",\n    \"date\": \"<dateTime>\",\n    \"comment\": \"<string>\"\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "18bc5aa7-9364-45a7-95d0-15e6ef539bcb",
+                                    "id": "20b64d8a-bd3f-46c7-8d6a-542cff8bdb09",
                                     "name": "Invalid comment ID format.",
                                     "originalRequest": {
                                         "url": {
@@ -4653,7 +4653,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "commentId"
                                                 }
                                             ]
@@ -4683,12 +4683,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "0d64cbd5-7fa2-4e1f-b5f8-967065d9b133",
+                                    "id": "3ccfb005-b65e-4423-a535-00d8fec2c94c",
                                     "name": "Comment not found.",
                                     "originalRequest": {
                                         "url": {
@@ -4708,7 +4708,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "commentId"
                                                 }
                                             ]
@@ -4738,7 +4738,7 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 }
@@ -4749,7 +4749,7 @@
                             }
                         },
                         {
-                            "id": "ae717cd7-5a23-492a-b74d-eec15c006dc6",
+                            "id": "5cb32cfe-839a-456e-b31f-51056a92c18b",
                             "name": "Update a comment",
                             "request": {
                                 "name": "Update a comment",
@@ -4769,7 +4769,7 @@
                                     "variable": [
                                         {
                                             "type": "any",
-                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                             "key": "commentId",
                                             "disabled": false,
                                             "description": {
@@ -4820,7 +4820,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "b807895a-cd9b-4e1f-9bad-f13e3a8439c2",
+                                    "id": "3f96e831-0bcb-4d4f-942d-6874bfa9d753",
                                     "name": "Comment updated successfully.",
                                     "originalRequest": {
                                         "url": {
@@ -4840,7 +4840,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "commentId"
                                                 }
                                             ]
@@ -4883,12 +4883,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"_id\": \"<string>\",\n  \"content\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"replyCount\": \"<integer>\",\n  \"likeCount\": \"<integer>\",\n  \"author\": {\n    \"_id\": \"<string>\",\n    \"type\": \"drep\",\n    \"name\": \"<string>\"\n  },\n  \"parentId\": \"<string>\",\n  \"userLiked\": \"<boolean>\",\n  \"withdrawalDetails\": {\n    \"category\": \"Inappropriate content\",\n    \"userId\": \"<string>\",\n    \"date\": \"<dateTime>\",\n    \"comment\": \"<string>\"\n  }\n}",
+                                    "body": "{\n  \"_id\": \"<string>\",\n  \"content\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"replyCount\": \"<integer>\",\n  \"likeCount\": \"<integer>\",\n  \"author\": {\n    \"_id\": \"<string>\",\n    \"type\": \"user\",\n    \"name\": \"<string>\"\n  },\n  \"parentId\": \"<string>\",\n  \"userLiked\": \"<boolean>\",\n  \"withdrawalDetails\": {\n    \"category\": \"Duplicate submission\",\n    \"userId\": \"<string>\",\n    \"date\": \"<dateTime>\",\n    \"comment\": \"<string>\"\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "92fa3b44-18b8-41f6-921a-a49f893bd9bf",
+                                    "id": "8f4d7166-35b7-40e2-b5ae-e97b0c035de0",
                                     "name": "Invalid request. Possible reasons: content exceeds 2000 characters, edit window (15 minutes) has passed.",
                                     "originalRequest": {
                                         "url": {
@@ -4908,7 +4908,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "commentId"
                                                 }
                                             ]
@@ -4951,12 +4951,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "d1f10288-276b-4351-99f8-acecd06360d1",
+                                    "id": "d8679b20-fe9b-4e99-bac4-f085d2dbf56c",
                                     "name": "Not authenticated.",
                                     "originalRequest": {
                                         "url": {
@@ -4976,7 +4976,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "commentId"
                                                 }
                                             ]
@@ -5019,12 +5019,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "6f2b6c7b-e240-4646-be66-1f61e915a987",
+                                    "id": "9581c3c2-3bf1-4e98-85a3-576a0b6ac509",
                                     "name": "Forbidden. Only the original author may edit.",
                                     "originalRequest": {
                                         "url": {
@@ -5044,7 +5044,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "commentId"
                                                 }
                                             ]
@@ -5087,12 +5087,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "6f047dbb-0f5a-49ce-8d57-90bdc17b4ac6",
+                                    "id": "1132ca7d-b6bd-4c28-9fe8-2c2c656aeaab",
                                     "name": "Comment not found.",
                                     "originalRequest": {
                                         "url": {
@@ -5112,7 +5112,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "commentId"
                                                 }
                                             ]
@@ -5155,12 +5155,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "56732334-4619-42ee-bbc2-ef3674d1b0ba",
+                                    "id": "712918bb-73c3-4fc7-953e-589f919513a4",
                                     "name": "Rate limit exceeded (5 per minute or 20 per hour per user).",
                                     "originalRequest": {
                                         "url": {
@@ -5180,7 +5180,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "commentId"
                                                 }
                                             ]
@@ -5223,7 +5223,7 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                    "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 }
@@ -5238,7 +5238,7 @@
                             "description": "",
                             "item": [
                                 {
-                                    "id": "db41ace3-385a-4934-b42e-5e0bf1afa6e7",
+                                    "id": "6f2bd184-33bf-4568-b108-168c3ab0062e",
                                     "name": "List replies to a comment",
                                     "request": {
                                         "name": "List replies to a comment",
@@ -5263,7 +5263,7 @@
                                                         "type": "text/plain"
                                                     },
                                                     "key": "status",
-                                                    "value": "withdrawnByAdmin"
+                                                    "value": "withdrawn"
                                                 },
                                                 {
                                                     "disabled": false,
@@ -5287,7 +5287,7 @@
                                             "variable": [
                                                 {
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "commentId",
                                                     "disabled": false,
                                                     "description": {
@@ -5309,7 +5309,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "ab81ac47-9b70-4e04-b543-93e85756875c",
+                                            "id": "bbdb26f8-240d-4038-aab3-035e0a53305b",
                                             "name": "Paginated list of replies.",
                                             "originalRequest": {
                                                 "url": {
@@ -5329,7 +5329,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "key": "status",
-                                                            "value": "withdrawnByAdmin"
+                                                            "value": "withdrawn"
                                                         },
                                                         {
                                                             "disabled": false,
@@ -5358,7 +5358,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "commentId"
                                                         }
                                                     ]
@@ -5380,12 +5380,12 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n  \"data\": [\n    {\n      \"_id\": \"<string>\",\n      \"content\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"replyCount\": \"<integer>\",\n      \"likeCount\": \"<integer>\",\n      \"author\": {\n        \"_id\": \"<string>\",\n        \"type\": \"user\",\n        \"name\": \"<string>\"\n      },\n      \"parentId\": \"<string>\",\n      \"userLiked\": \"<boolean>\",\n      \"withdrawalDetails\": {\n        \"category\": \"Inappropriate content\",\n        \"userId\": \"<string>\",\n        \"date\": \"<dateTime>\",\n        \"comment\": \"<string>\"\n      }\n    },\n    {\n      \"_id\": \"<string>\",\n      \"content\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"replyCount\": \"<integer>\",\n      \"likeCount\": \"<integer>\",\n      \"author\": {\n        \"_id\": \"<string>\",\n        \"type\": \"proposer\",\n        \"name\": \"<string>\"\n      },\n      \"parentId\": \"<string>\",\n      \"userLiked\": \"<boolean>\",\n      \"withdrawalDetails\": {\n        \"category\": \"Spam\",\n        \"userId\": \"<string>\",\n        \"date\": \"<dateTime>\",\n        \"comment\": \"<string>\"\n      }\n    }\n  ],\n  \"meta\": {\n    \"page\": \"<integer>\",\n    \"limit\": \"<integer>\",\n    \"total\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"hasNextPage\": \"<boolean>\",\n    \"hasPreviousPage\": \"<boolean>\"\n  }\n}",
+                                            "body": "{\n  \"data\": [\n    {\n      \"_id\": \"<string>\",\n      \"content\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"replyCount\": \"<integer>\",\n      \"likeCount\": \"<integer>\",\n      \"author\": {\n        \"_id\": \"<string>\",\n        \"type\": \"admin\",\n        \"name\": \"<string>\"\n      },\n      \"parentId\": \"<string>\",\n      \"userLiked\": \"<boolean>\",\n      \"withdrawalDetails\": {\n        \"category\": \"Policy violation\",\n        \"userId\": \"<string>\",\n        \"date\": \"<dateTime>\",\n        \"comment\": \"<string>\"\n      }\n    },\n    {\n      \"_id\": \"<string>\",\n      \"content\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"replyCount\": \"<integer>\",\n      \"likeCount\": \"<integer>\",\n      \"author\": {\n        \"_id\": \"<string>\",\n        \"type\": \"drep\",\n        \"name\": \"<string>\"\n      },\n      \"parentId\": \"<string>\",\n      \"userLiked\": \"<boolean>\",\n      \"withdrawalDetails\": {\n        \"category\": \"Policy violation\",\n        \"userId\": \"<string>\",\n        \"date\": \"<dateTime>\",\n        \"comment\": \"<string>\"\n      }\n    }\n  ],\n  \"meta\": {\n    \"page\": \"<integer>\",\n    \"limit\": \"<integer>\",\n    \"total\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"hasNextPage\": \"<boolean>\",\n    \"hasPreviousPage\": \"<boolean>\"\n  }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "177ef856-fd21-4ea5-8b0c-fb436029b168",
+                                            "id": "50f9299a-cf20-4236-8afa-160669c72cb7",
                                             "name": "Invalid request or comment ID format.",
                                             "originalRequest": {
                                                 "url": {
@@ -5405,7 +5405,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "key": "status",
-                                                            "value": "withdrawnByAdmin"
+                                                            "value": "withdrawn"
                                                         },
                                                         {
                                                             "disabled": false,
@@ -5434,7 +5434,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "commentId"
                                                         }
                                                     ]
@@ -5456,12 +5456,12 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "8e4e70e3-1604-427c-b9df-140aea3e9886",
+                                            "id": "84c27826-1fbb-457a-aef2-ea661a2b1994",
                                             "name": "Parent comment not found.",
                                             "originalRequest": {
                                                 "url": {
@@ -5481,7 +5481,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "key": "status",
-                                                            "value": "withdrawnByAdmin"
+                                                            "value": "withdrawn"
                                                         },
                                                         {
                                                             "disabled": false,
@@ -5510,7 +5510,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "commentId"
                                                         }
                                                     ]
@@ -5532,7 +5532,7 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         }
@@ -5549,7 +5549,7 @@
                             "description": "",
                             "item": [
                                 {
-                                    "id": "56b9f4ab-d6bc-43b3-aaac-3ce8f39131cb",
+                                    "id": "1aa39b70-75e5-42c5-ab70-776dbc031097",
                                     "name": "Toggle like on a comment",
                                     "request": {
                                         "name": "Toggle like on a comment",
@@ -5570,7 +5570,7 @@
                                             "variable": [
                                                 {
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "commentId",
                                                     "disabled": false,
                                                     "description": {
@@ -5608,7 +5608,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "862061e2-8340-4639-a318-92e71f2525d5",
+                                            "id": "b71f1126-c93d-463f-bbe7-784f9b9fa5ef",
                                             "name": "Like removed (toggled off).",
                                             "originalRequest": {
                                                 "url": {
@@ -5629,7 +5629,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "commentId"
                                                         }
                                                     ]
@@ -5664,7 +5664,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "9065285e-6660-4994-bff2-18b1dead35f5",
+                                            "id": "87ca1bff-b1fc-46b9-a955-fa790a91b959",
                                             "name": "Like added (toggled on).",
                                             "originalRequest": {
                                                 "url": {
@@ -5685,7 +5685,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "commentId"
                                                         }
                                                     ]
@@ -5720,7 +5720,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "e77937db-2d24-4845-90aa-56aad7f16591",
+                                            "id": "4d493d5f-f308-431d-91fc-893c227f3d90",
                                             "name": "Invalid request. Possible reasons: comment is not live, proposal is not live, past feedbackEndDate.",
                                             "originalRequest": {
                                                 "url": {
@@ -5741,7 +5741,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "commentId"
                                                         }
                                                     ]
@@ -5771,12 +5771,12 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "c8752fe4-e4ab-4331-9223-53fa6064d49b",
+                                            "id": "66d2ddeb-f17b-4e4e-9001-a56f0a00ed01",
                                             "name": "Not authenticated.",
                                             "originalRequest": {
                                                 "url": {
@@ -5797,7 +5797,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "commentId"
                                                         }
                                                     ]
@@ -5827,12 +5827,12 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "72830bd4-f9a8-46fb-b28b-b277ac5b0e58",
+                                            "id": "3129598e-4337-4206-bc87-d17e4b345569",
                                             "name": "Comment not found.",
                                             "originalRequest": {
                                                 "url": {
@@ -5853,7 +5853,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "commentId"
                                                         }
                                                     ]
@@ -5883,12 +5883,12 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "cc007088-9d8f-4b6c-a90c-6eddfcfa311a",
+                                            "id": "3c13ae05-2ddc-449e-a42a-b0452e2eac6b",
                                             "name": "Rate limit exceeded (10 requests per minute per user).",
                                             "originalRequest": {
                                                 "url": {
@@ -5909,7 +5909,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "commentId"
                                                         }
                                                     ]
@@ -5939,7 +5939,7 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         }
@@ -5956,7 +5956,7 @@
                             "description": "",
                             "item": [
                                 {
-                                    "id": "38ca2b30-1010-4817-bc87-96b3349b4426",
+                                    "id": "256cb6fe-ede2-41e7-b587-4e09c5b90a1d",
                                     "name": "Admin withdraw a comment",
                                     "request": {
                                         "name": "Admin withdraw a comment",
@@ -5977,7 +5977,7 @@
                                             "variable": [
                                                 {
                                                     "type": "any",
-                                                    "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                    "value": "d1D36d221Aeba96D14Ed2acd",
                                                     "key": "commentId",
                                                     "disabled": false,
                                                     "description": {
@@ -6000,7 +6000,7 @@
                                         "method": "PUT",
                                         "body": {
                                             "mode": "raw",
-                                            "raw": "{\n  \"category\": \"Policy violation\",\n  \"comment\": \"<string>\"\n}",
+                                            "raw": "{\n  \"category\": \"Duplicate\",\n  \"comment\": \"<string>\"\n}",
                                             "options": {
                                                 "raw": {
                                                     "headerFamily": "json",
@@ -6028,7 +6028,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "b3939cf2-13ad-4edc-931b-4e91c0c4e76a",
+                                            "id": "e8781002-9c1d-4c7f-8f0f-2b2d4f0fdb56",
                                             "name": "Comment withdrawn successfully.",
                                             "originalRequest": {
                                                 "url": {
@@ -6049,7 +6049,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "commentId"
                                                         }
                                                     ]
@@ -6075,7 +6075,7 @@
                                                 "method": "PUT",
                                                 "body": {
                                                     "mode": "raw",
-                                                    "raw": "{\n  \"category\": \"Policy violation\",\n  \"comment\": \"<string>\"\n}",
+                                                    "raw": "{\n  \"category\": \"Duplicate\",\n  \"comment\": \"<string>\"\n}",
                                                     "options": {
                                                         "raw": {
                                                             "headerFamily": "json",
@@ -6092,12 +6092,12 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n  \"_id\": \"<string>\",\n  \"content\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"replyCount\": \"<integer>\",\n  \"likeCount\": \"<integer>\",\n  \"author\": {\n    \"_id\": \"<string>\",\n    \"type\": \"drep\",\n    \"name\": \"<string>\"\n  },\n  \"parentId\": \"<string>\",\n  \"userLiked\": \"<boolean>\",\n  \"withdrawalDetails\": {\n    \"category\": \"Inappropriate content\",\n    \"userId\": \"<string>\",\n    \"date\": \"<dateTime>\",\n    \"comment\": \"<string>\"\n  }\n}",
+                                            "body": "{\n  \"_id\": \"<string>\",\n  \"content\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"replyCount\": \"<integer>\",\n  \"likeCount\": \"<integer>\",\n  \"author\": {\n    \"_id\": \"<string>\",\n    \"type\": \"user\",\n    \"name\": \"<string>\"\n  },\n  \"parentId\": \"<string>\",\n  \"userLiked\": \"<boolean>\",\n  \"withdrawalDetails\": {\n    \"category\": \"Duplicate submission\",\n    \"userId\": \"<string>\",\n    \"date\": \"<dateTime>\",\n    \"comment\": \"<string>\"\n  }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "6ff62489-6cff-450e-b406-2378d6b4574d",
+                                            "id": "31d310c3-f5fc-4efa-a9e3-dde7795670eb",
                                             "name": "Invalid request. Possible reasons: invalid category, comment is not live, past feedbackEndDate.",
                                             "originalRequest": {
                                                 "url": {
@@ -6118,7 +6118,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "commentId"
                                                         }
                                                     ]
@@ -6144,7 +6144,7 @@
                                                 "method": "PUT",
                                                 "body": {
                                                     "mode": "raw",
-                                                    "raw": "{\n  \"category\": \"Policy violation\",\n  \"comment\": \"<string>\"\n}",
+                                                    "raw": "{\n  \"category\": \"Duplicate\",\n  \"comment\": \"<string>\"\n}",
                                                     "options": {
                                                         "raw": {
                                                             "headerFamily": "json",
@@ -6161,12 +6161,12 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "cb3400fd-52f3-4e94-a6bb-f409ecf2404c",
+                                            "id": "eb8fdd4e-5b06-47d6-87af-e5746b99f495",
                                             "name": "Not authenticated.",
                                             "originalRequest": {
                                                 "url": {
@@ -6187,7 +6187,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "commentId"
                                                         }
                                                     ]
@@ -6213,7 +6213,7 @@
                                                 "method": "PUT",
                                                 "body": {
                                                     "mode": "raw",
-                                                    "raw": "{\n  \"category\": \"Policy violation\",\n  \"comment\": \"<string>\"\n}",
+                                                    "raw": "{\n  \"category\": \"Duplicate\",\n  \"comment\": \"<string>\"\n}",
                                                     "options": {
                                                         "raw": {
                                                             "headerFamily": "json",
@@ -6230,12 +6230,12 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "d2181613-3661-4cba-95e7-6efae7fa9d87",
+                                            "id": "1e40ea99-9a47-4aea-a247-cb0a376ca9e4",
                                             "name": "Forbidden. Only vote cycle admins may withdraw comments.",
                                             "originalRequest": {
                                                 "url": {
@@ -6256,7 +6256,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "commentId"
                                                         }
                                                     ]
@@ -6282,7 +6282,7 @@
                                                 "method": "PUT",
                                                 "body": {
                                                     "mode": "raw",
-                                                    "raw": "{\n  \"category\": \"Policy violation\",\n  \"comment\": \"<string>\"\n}",
+                                                    "raw": "{\n  \"category\": \"Duplicate\",\n  \"comment\": \"<string>\"\n}",
                                                     "options": {
                                                         "raw": {
                                                             "headerFamily": "json",
@@ -6299,12 +6299,12 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "1bafbec2-f44c-4d90-a8c3-c4791439659a",
+                                            "id": "42946e9c-6ca6-413d-9a46-3f5af143c027",
                                             "name": "Comment not found.",
                                             "originalRequest": {
                                                 "url": {
@@ -6325,7 +6325,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "commentId"
                                                         }
                                                     ]
@@ -6351,7 +6351,7 @@
                                                 "method": "PUT",
                                                 "body": {
                                                     "mode": "raw",
-                                                    "raw": "{\n  \"category\": \"Policy violation\",\n  \"comment\": \"<string>\"\n}",
+                                                    "raw": "{\n  \"category\": \"Duplicate\",\n  \"comment\": \"<string>\"\n}",
                                                     "options": {
                                                         "raw": {
                                                             "headerFamily": "json",
@@ -6368,12 +6368,12 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "0ecc4c4e-d4b1-412c-ba36-c56c573932af",
+                                            "id": "799b1ef5-fae8-46f3-8436-4ac5dfafc861",
                                             "name": "Rate limit exceeded (10 requests per minute per user).",
                                             "originalRequest": {
                                                 "url": {
@@ -6394,7 +6394,7 @@
                                                                 "type": "text/plain"
                                                             },
                                                             "type": "any",
-                                                            "value": "C5FE5fdDbc2D74a71b70cf3B",
+                                                            "value": "d1D36d221Aeba96D14Ed2acd",
                                                             "key": "commentId"
                                                         }
                                                     ]
@@ -6420,7 +6420,7 @@
                                                 "method": "PUT",
                                                 "body": {
                                                     "mode": "raw",
-                                                    "raw": "{\n  \"category\": \"Policy violation\",\n  \"comment\": \"<string>\"\n}",
+                                                    "raw": "{\n  \"category\": \"Duplicate\",\n  \"comment\": \"<string>\"\n}",
                                                     "options": {
                                                         "raw": {
                                                             "headerFamily": "json",
@@ -6437,7 +6437,7 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": false\n  }\n}",
+                                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"<string>\",\n  \"errors\": {\n    \"key_0\": 726\n  }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         }
@@ -6462,7 +6462,7 @@
         }
     ],
     "info": {
-        "_postman_id": "080f5d1e-f2d9-451b-a382-da68e5a67f57",
+        "_postman_id": "2022035c-b029-4b79-96d0-d374df2cd750",
         "name": "Ekklesia Proposals API",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         "description": {


### PR DESCRIPTION
Align the Proposals API spec with the deployed Hydra Voting API, which returns treasuryDonation as a lovelace amount (0 when none is required).

Closes #43