### PR TITLE
Exempt dependency bumps from the changelog gate and group them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
       semver-patch-days: 3
       semver-minor-days: 7
       semver-major-days: 14
+    groups:
+      # Everything here is tooling for building and checking the site, so
+      # these land together rather than as one pull request each.
+      npm-dependencies:
+        patterns: ['*']
 
   - package-ecosystem: 'bundler'
     directory: '/'
@@ -19,6 +24,9 @@ updates:
       semver-patch-days: 3
       semver-minor-days: 7
       semver-major-days: 14
+    groups:
+      jekyll:
+        patterns: ['*']
 
   - package-ecosystem: 'github-actions'
     directory: '/'
@@ -26,3 +34,11 @@ updates:
       interval: 'weekly'
     cooldown:
       default-days: 7
+    groups:
+      actions:
+        patterns: ['*']
+    ignore:
+      # The workflows track floating major tags on purpose. Dependabot reads
+      # ruby/setup-ruby@v1 as version 1 and proposes an exact patch pin,
+      # which would freeze it while the other actions keep floating.
+      - dependency-name: 'ruby/setup-ruby'

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -8,7 +8,11 @@ on:
 jobs:
   changeset:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.pull_request.labels.*.name, 'skip-changelog')"
+    # Dependency bumps do not change what a reader of the documentation sees,
+    # so they are not expected to carry a changelog entry.
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Two problems showed up as soon as Dependabot ran for the first time.

## The changelog gate blocks every dependency bump

Every one of the ten Dependabot pull requests failed the changelog check. A bump carries no changeset, and Dependabot has no way to add one, so the gate can never be satisfied. It was blocking pull requests it was never meant to apply to.

CONTRIBUTING.md already says an entry is for changes that affect what a reader can rely on, and a dev dependency bump is not one. The check now skips Dependabot accordingly.

## Ten pull requests for ten dependencies

The first run opened one pull request per dependency. Each ecosystem is now grouped into a single pull request, so a weekly run produces at most three rather than ten.

## ruby/setup-ruby

Added to the ignore list. The workflows track floating major tags on purpose. Dependabot reads `ruby/setup-ruby@v1` as version 1 and proposed pinning it to an exact `1.317.0`, which would freeze that one action while the rest keep floating.

The ten open pull requests still need triaging by hand. Grouping applies to future runs, not existing ones.