### PR TITLE
Cut documentation releases through an accumulating release pull request

### DIFF
--- a/.changeset/lucky-pandas-shine.md
+++ b/.changeset/lucky-pandas-shine.md
@@ -1,0 +1,6 @@
+---
+"docs": minor
+---
+
+Show the documentation version and build date in the site footer, and cut
+releases through an accumulating release pull request.

--- a/.github/scripts/write-version-data.mjs
+++ b/.github/scripts/write-version-data.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+// Write the site version and build date where Jekyll can read them.
+//
+// Jekyll has no way to read package.json, so the build writes the values it
+// needs into _data/version.yml first. The file is generated, not committed,
+// which keeps the published version tied to the build rather than to whoever
+// last remembered to update a string by hand.
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
+
+const { version } = JSON.parse(readFileSync('package.json', 'utf8'));
+const built = new Date().toISOString().slice(0, 10);
+
+mkdirSync('_data', { recursive: true });
+writeFileSync('_data/version.yml', `version: '${version}'\nbuilt: '${built}'\n`);
+
+console.log(`_data/version.yml written: v${version}, built ${built}`);

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -9,9 +9,12 @@ jobs:
   changeset:
     runs-on: ubuntu-latest
     # Dependency bumps do not change what a reader of the documentation sees,
-    # so they are not expected to carry a changelog entry.
+    # so they are not expected to carry a changelog entry. The release pull
+    # request is exempt for the opposite reason: it consumes the accumulated
+    # entries rather than adding one.
     if: >-
       github.actor != 'dependabot[bot]' &&
+      github.actor != 'ekklesia-release-manager[bot]' &&
       !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
     steps:
       - name: Checkout
@@ -21,7 +24,7 @@ jobs:
 
       - name: Check for a changeset
         run: |
-          if git diff --name-only \
+          if git diff --name-only --diff-filter=AM \
             "origin/${{ github.base_ref }}...HEAD" \
             | grep -qE '^\.changeset/.+\.md$'; then
             echo "Changeset found."

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Generate Postman collections
         run: npm run postman
 
+      - name: Write the version data
+        run: npm run version:data
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint a Release Manager token
+        id: token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_MANAGER_APP_ID }}
+          private-key: ${{ secrets.RELEASE_MANAGER_APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.token.outputs.token }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # With pending changesets this opens or refreshes the version pull
+      # request. With none it does nothing, which is the state right after
+      # that pull request merges, and the tagging steps below take over.
+      - name: Open or refresh the version pull request
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: npm run version
+          title: 'Release the documentation'
+          commit: 'Version the documentation'
+        env:
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+
+      - name: Read the current version
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        id: version
+        run: |
+          version=$(node -p "require('./package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          if git rev-parse "v$version" >/dev/null 2>&1; then
+            echo "tagged=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tagged=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Reached only on the push that merged the version pull request, since
+      # that is the first time this version exists without a tag.
+      - name: Tag and publish the release
+        if: >-
+          steps.changesets.outputs.hasChangesets == 'false' &&
+          steps.version.outputs.tagged == 'false'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          notes=$(awk '/^## /{n++} n==1' CHANGELOG.md | tail -n +2)
+          if [ -z "$notes" ]; then
+            notes="See CHANGELOG.md."
+          fi
+          gh release create "v$VERSION" \
+            --title "Documentation v$VERSION" \
+            --notes "$notes" \
+            --target main

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,10 @@ __tests/
 # Local test infrastructure
 docker-compose.test.yml
 .env
-scripts/
+# Anchored to the root: the local test helpers live in /scripts, while
+# .github/scripts holds build tooling that has to be committed.
+/scripts/
 /test-results.txt
+
+# Generated at build time from package.json
+_data/version.yml

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,6 +6,9 @@
     </div>
     <div class="footer-meta">
       <span>&copy; Adam Dean &amp; Mad Orkestra {{ 'now' | date: '%Y' }}</span>
+      {% if site.data.version %}
+      <span class="footer-version">v{{ site.data.version.version }} &middot; built {{ site.data.version.built }}</span>
+      {% endif %}
     </div>
   </div>
 </footer>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -562,6 +562,14 @@ img {
 .footer-meta {
   font-size: 0.75rem;
   color: var(--fg-dim);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.footer-version {
+  font-variant-numeric: tabular-nums;
+  opacity: 0.8;
 }
 
 /* ---- Responsive ---- */

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "changeset": "changeset",
     "version": "changeset version",
+    "version:data": "node .github/scripts/write-version-data.mjs",
     "fmt": "prettier --write '**/*.md' --ignore-path .prettierignore",
     "fmt:check": "prettier --check '**/*.md' --ignore-path .prettierignore",
     "lint:specs": "redocly lint api/proposals/openapi.yaml api/voting/openapi.v0.yaml api/voting/openapi.v1.yaml",


### PR DESCRIPTION
Merging to `main` already publishes the site, so a release here cannot mean "make it live". It marks a version and a changelog. This wires that up.

## How it works

Changesets accumulate as changes land on `main`. The Release Manager keeps a single open release pull request showing exactly what is unreleased. Merging that pull request versions the package, writes `CHANGELOG.md`, tags `vX.Y.Z`, and publishes a GitHub release with the notes for that version. Nothing forces a cadence.

Releases run as `ekklesia-release-manager[bot]`, using the org-level `RELEASE_MANAGER_APP_ID` variable and `RELEASE_MANAGER_APP_PRIVATE_KEY` secret. This is the first repository to actually run that automation.

## Version on the site

The footer now shows the version and build date, written into `_data/version.yml` from `package.json` during the Pages build. Jekyll cannot read `package.json`, hence the generated file, which is ignored rather than committed so it always reflects the build rather than whoever last edited a string.

## Two fixes the release flow exposed

The release pull request would have failed the changelog gate, since it consumes the accumulated entries rather than adding one. It is now exempt alongside Dependabot.

The gate also matched deleted changeset files, which is exactly what the release pull request does, so it would have passed for the wrong reason. Restricted to added and modified files.

## One unrelated fix

The `scripts/` ignore rule was unanchored, so it matched any directory named `scripts` at any depth, including the new `.github/scripts`. Anchored to the root. The local test helpers in `/scripts` stay ignored.