### PR TITLE
Route Hydra SDK issues to that project's own tracker

### DIFF
--- a/.changeset/brave-otters-wander.md
+++ b/.changeset/brave-otters-wander.md
@@ -1,0 +1,6 @@
+---
+"docs": patch
+---
+
+Route Hydra SDK issues to that project's own tracker rather than the central
+one.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,7 +25,6 @@ body:
         - helpers
         - proposal-module
         - rewards
-        - hydra-sdk
         - docs
         - not sure
     validations:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -20,7 +20,6 @@ body:
         - helpers
         - proposal-module
         - rewards
-        - hydra-sdk
         - docs
         - not sure
     validations:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -21,7 +21,6 @@ body:
         - helpers
         - proposal-module
         - rewards
-        - hydra-sdk
         - docs
         - not sure
     validations:

--- a/.github/workflows/label-component.yml
+++ b/.github/workflows/label-component.yml
@@ -22,7 +22,6 @@ jobs:
               'helpers',
               'proposal-module',
               'rewards',
-              'hydra-sdk',
               'docs',
             ];
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,16 +4,20 @@ Thanks for your interest in improving the Ekklesia documentation.
 
 ## Filing issues
 
-This repository is the central issue tracker for the whole Ekklesia system.
-Bugs, feature requests, and questions about the frontend, backend, Hydra
-integration, helpers, proposal module, rewards, the SDK, or the documentation
-itself all belong here, filed through
+This repository is the central issue tracker for the Ekklesia system. Bugs,
+feature requests, and questions about the frontend, backend, Hydra integration,
+helpers, proposal module, rewards, or the documentation itself all belong here,
+filed through
 [the issue templates](https://github.com/Lerna-Labs/ekklesia-docs/issues/new/choose).
 Every template asks which component is involved so the issue reaches the right
 place.
 
-Security vulnerabilities are the one exception. See [SECURITY.md](SECURITY.md)
-and report privately, never as a public issue in this or any other repository.
+The Hydra SDK is the exception. It is a general purpose library for building on
+Cardano Hydra rather than a part of Ekklesia, so it keeps its own tracker. File
+SDK issues in [hydra-sdk](https://github.com/lerna-labs/hydra-sdk/issues).
+
+Security vulnerabilities go to neither tracker. See [SECURITY.md](SECURITY.md)
+and report privately, never as a public issue in any repository.
 
 ## Making a change
 


### PR DESCRIPTION
The Hydra SDK is a general purpose library for building on Cardano Hydra rather than a component of Ekklesia. Someone using the SDK has no reason to think of it as an Ekklesia part, or to file against an Ekklesia tracker, so it keeps its own.

Removes the `hydra-sdk` option from the component field on all three issue templates, removes it from the set of labels the component workflow can apply, and points the contributing guide at the SDK's own tracker.

The `hydra-sdk` label is being deleted separately. It carried no issues, having been created alongside the templates earlier today.

Note that hydra-sdk still has a redirect stub sending issues here. That should come out, but it needs its own issue templates first, otherwise removing the stub just re-enables blank issues with no guidance. Left for a follow-up in that repository.