### PR TITLE
Publish the site on release rather than on every merge

### DIFF
--- a/.changeset/olive-pumas-attend.md
+++ b/.changeset/olive-pumas-attend.md
@@ -1,0 +1,6 @@
+---
+"docs": minor
+---
+
+Publish the site when a release is cut rather than on every merge, so what is
+live always matches a released version.

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,11 @@
 name: Deploy to GitHub Pages
 
+# Publishing is tied to a release rather than to every merge, so what is
+# live always corresponds to a version and a changelog entry. Merging to
+# main accumulates changes; cutting the release publishes them.
 on:
-  push:
-    branches: [main]
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       reason:
@@ -25,6 +28,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Build the tag that was released, not whatever main has drifted
+          # to since. A manual run falls back to the default branch.
+          ref: ${{ github.event.release.tag_name || github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Merging to `main` published immediately, so the live site and the version it claimed could drift apart. Content shipped without a version attached, and the footer version only moved when a release happened to be cut.

Publishing now runs on `release: published`, which the release workflow triggers when the release pull request merges. Merging to `main` accumulates changes; cutting the release publishes them. What is live always corresponds to a version and a changelog entry.

The build checks out the released tag rather than `main`, so a merge landing between the release and the deploy cannot leak into the published site. Manual deploys through workflow dispatch still work and fall back to the default branch.

## One consequence worth knowing

A change merged with the `skip-changelog` label produces no changeset, so it does not move the release pull request. Under the old trigger it published anyway on merge. Under this one it waits for the next release, which may never be cut if nothing else lands.

That is an argument for dropping `skip-changelog` for human pull requests entirely, so every merge contributes to a release. Raised separately rather than decided here. Until then, a manual workflow dispatch will publish a stranded change.