### PR TITLE
Require a changelog entry on every change

### DIFF
--- a/.changeset/quiet-moons-repeat.md
+++ b/.changeset/quiet-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Require a changelog entry on every change, including editorial fixes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,4 +6,5 @@
 
 - [ ] Markdown is formatted (`npm run fmt:check`)
 - [ ] OpenAPI specs validate (`npm run lint:specs`), if specs were touched
-- [ ] Changelog entry added (`npx changeset`), or not needed for this change
+- [ ] Changelog entry added (`npx changeset`), `patch` for editorial work,
+      `minor` for substantive changes

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -3,19 +3,19 @@ name: Changelog check
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
 
 jobs:
   changeset:
     runs-on: ubuntu-latest
-    # Dependency bumps do not change what a reader of the documentation sees,
-    # so they are not expected to carry a changelog entry. The release pull
-    # request is exempt for the opposite reason: it consumes the accumulated
-    # entries rather than adding one.
+    # The only exemptions are the two identities that cannot add an entry:
+    # Dependabot, and the release pull request, which consumes the accumulated
+    # entries rather than adding one. Everything else needs one, including
+    # editorial work, since the site publishes on release and a change with no
+    # entry would sit merged but unpublished.
     if: >-
       github.actor != 'dependabot[bot]' &&
-      github.actor != 'ekklesia-release-manager[bot]' &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
+      github.actor != 'ekklesia-release-manager[bot]'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,8 +30,9 @@ jobs:
             echo "Changeset found."
           else
             echo "No changeset found in this pull request."
-            echo "Run 'npx changeset' and commit the generated file, or apply"
-            echo "the 'skip-changelog' label if this change does not alter"
-            echo "documented behavior. See CONTRIBUTING.md."
+            echo "Run 'npx changeset' and commit the generated file."
+            echo "Use 'patch' for editorial work such as typos and wording,"
+            echo "'minor' for pages added or moved, spec changes, or documented"
+            echo "behavior that now reads differently. See CONTRIBUTING.md."
             exit 1
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,7 @@ Merging to `main` builds and deploys the site to
 
 ## Changelog entries
 
-The documentation is versioned so it is always clear which release is published.
-Not every change needs an entry, though. Add one with:
+Every change needs a changelog entry. Add one with:
 
 ```bash
 npx changeset
@@ -49,16 +48,24 @@ npx changeset
 and follow the prompts. It writes a small markdown file under `.changeset/` that
 you commit alongside your change.
 
-Add a changelog entry when the change affects what a reader can rely on:
+The documentation is versioned so it is always clear which release is published,
+and the site publishes when a release is cut rather than on every merge. A
+change with no entry does not move the release forward, so it would sit merged
+but unpublished. That is why editorial work counts too: fixing a typo is a real
+change to what a reader sees.
 
-- An OpenAPI spec changes, including a version bump or a corrected field type
-- A page is added, removed, renamed, or moved to a different section
-- Documented behavior changes, so a reader following the old text would now get
-  a different result
+Pick the bump from what the change does:
 
-Skip the entry for changes that do not alter meaning, such as typo and grammar
-fixes, formatting, or link repairs. Apply the `skip-changelog` label to the pull
-request so the check passes.
+- `patch` for editorial work: typos, grammar, wording, formatting, broken links
+- `minor` for substantive work: a page added, removed, renamed, or moved, an
+  OpenAPI spec change, or documented behavior that now reads differently
+
+Write the entry for someone reading the changelog later, not for the reviewer
+reading the diff. "Correct the deposit field type in the proposals spec" is
+useful. "Fix typo" is not.
+
+Dependency updates and the release pull request are exempt, since neither can
+add an entry. Nothing else is.
 
 ## Getting set up
 


### PR DESCRIPTION
Editorial work is still a change to what a reader sees. Fixing a typo is a real fix, and the changelog should say so.

There is a mechanical reason too, now that the site publishes on release rather than on merge. A change carrying no changeset does not move the release pull request, so it sits merged but unpublished until something else triggers a release. The `skip-changelog` escape quietly created that trap.

## What changes

The label escape is gone. The only exemptions left are the two identities that cannot add an entry: Dependabot, and the release pull request, which consumes the accumulated entries rather than adding one.

`CONTRIBUTING.md` now says which bump to pick, `patch` for editorial work and `minor` for substantive changes, and asks for entries written for someone reading the changelog later rather than the reviewer reading the diff. The pull request template matches.

The check also no longer runs on `labeled` and `unlabeled`. Those fired it up to five times per pull request as Dependabot applied its labels, and now that labels do not affect the outcome the extra runs did nothing.

The `skip-changelog` label is being deleted separately. It was applied to #66 and #73 before this landed.