### PR TITLE
update: audit specVersion ekklesia\2.0

### DIFF
--- a/.changeset/olive-falcons-verify.md
+++ b/.changeset/olive-falcons-verify.md
@@ -1,0 +1,11 @@
+---
+"docs": patch
+---
+
+Teach the ballot auditor that specVersion 2.0 hashes vote evidence envelopes
+as canonical JSON. Step 6 now picks the envelope encoding from the ballot's
+declared specVersion instead of always serializing in insertion order, so
+2.0 ballots verify while previously settled ballots keep verifying under the
+older encoding. When no version matches, the failure now reports whether the
+other encoding would have matched, so a future format change reads as a
+format change rather than as evidence tampering.

--- a/downloads/_files/audit_ballot.py
+++ b/downloads/_files/audit_ballot.py
@@ -88,6 +88,7 @@ License: MIT  (this script is part of the Ekklesia public docs)
 
 import argparse
 import json
+import re
 import sys
 import urllib.error
 import urllib.request
@@ -143,8 +144,59 @@ MAX_VOTE_VERSIONS = 10000
 # heuristic to distinguish a Hydra fanout from an admin-wallet rebalance.
 SCRIPT_ADDR_PREFIXES = ("addr_test1w", "addr1w")
 
+# specVersion at which vote evidence envelopes switched to CANONICAL JSON
+# (lexicographically sorted keys) for their blake2b_256 commitment. Before
+# this, envelopes were hashed as JSON.stringify emitted them, i.e. in
+# insertion order. The two encodings differ whenever an envelope's keys are
+# not already alphabetical, so Step 6 must hash under the encoding the
+# producer actually used or every committed voteHash misses.
+#
+# The scope of this is deliberately NARROW. Canonical encoding applies only to
+# the evidence envelope hash in Step 6. Two neighbouring commitments stay
+# insertion-order under 2.0 by design, both confirmed against mainnet ballot
+# 4e64f912...:
+#
+#   - Step 2, the (600) question contentHash. Its question objects are not
+#     alphabetical, so this is load-bearing: hashing them sorted rebuilds a
+#     merkle root that does NOT match the on-chain (600) root.
+#   - Step 7, the signedPayload -> COSE payload binding. signedPayload happens
+#     to be alphabetical at every level today, so both encodings agree and the
+#     distinction is currently unobservable there.
+#
+# Do NOT widen this gate to those paths without re-verifying both against a
+# settled ballot.
+CANONICAL_EVIDENCE_MIN_MAJOR = 2
+
 
 # --- Tiny helpers ------------------------------------------------------------
+
+def spec_version_major(spec_version: Any) -> Any:
+    """Major version parsed out of a specVersion string, or None if unknown.
+
+    Handles the namespaced 'ekklesia/2.0' form as well as bare numerics like
+    '0.3.0'. Returns None when the field is absent or unparseable; callers
+    treat that as 'unknown' rather than silently assuming an encoding.
+    """
+    if not isinstance(spec_version, str):
+        return None
+    m = re.match(r"^(\d+)", spec_version.split("/")[-1].strip())
+    return int(m.group(1)) if m else None
+
+
+def evidence_hash_bytes(obj: Any, spec_major: Any) -> bytes:
+    """Serialize a vote evidence envelope for its blake2b_256 commitment.
+
+    Sorts keys for specVersion >= CANONICAL_EVIDENCE_MIN_MAJOR, otherwise
+    preserves insertion order to match older JSON.stringify-based producers.
+    An unknown (None) major is treated as pre-canonical, which is the safe
+    default: it keeps previously settled ballots verifying, and Step 6 warns
+    loudly when it cannot determine the version.
+    """
+    canonical = spec_major is not None and spec_major >= CANONICAL_EVIDENCE_MIN_MAJOR
+    return json.dumps(
+        obj, separators=(",", ":"), ensure_ascii=False, sort_keys=canonical
+    ).encode("utf-8")
+
 
 def blake2b_256(data: bytes) -> bytes:
     return blake2b(data, digest_size=32).digest()
@@ -1622,6 +1674,24 @@ def audit_one_ballot(report: Report, fingerprint: str, pair: dict, gateway: str,
 
     # --- Step 6: per-voter evidence file hashes match committed voteHashes --
     report.step("Step 6: per-voter evidence file blake2b_256 matches each committed voteHash")
+    # Pick the envelope encoding from the ballot's declared specVersion. The
+    # version is read from results.json rather than from the evidence files
+    # themselves: results.json bytes were just verified against the on-chain
+    # (601) resultsHash in Step 3, so this signal is anchored to L1 and cannot
+    # be steered by a tampered evidence file choosing its own encoding.
+    spec_version = results.get("specVersion")
+    spec_major = spec_version_major(spec_version)
+    if spec_major is None:
+        report.warn(
+            f"results.json declares no parseable specVersion (got {spec_version!r}); "
+            f"hashing evidence envelopes in insertion order (pre-2.0 behaviour). "
+            f"If this ballot was produced under a newer spec, Step 6 will fail for "
+            f"every voter."
+        )
+    canonical_evidence = (spec_major is not None
+                          and spec_major >= CANONICAL_EVIDENCE_MIN_MAJOR)
+    encoding = "canonical (sorted keys)" if canonical_evidence else "insertion order"
+    report.info(f"specVersion {spec_version} -> hashing evidence envelopes as {encoding}")
     # Cache the matched evidence per voter for the deeper steps below — keyed
     # by the proof-package's `name` (i.e., the voter token name).
     matched_evidence: dict = {}
@@ -1639,6 +1709,11 @@ def audit_one_ballot(report: Report, fingerprint: str, pair: dict, gateway: str,
         matched_obj = None
         last_err = None
         probed = 0
+        # If nothing matches under the declared encoding, note whether the
+        # OTHER encoding would have matched. That distinguishes an unannounced
+        # canonicalization change from actual evidence tampering, which would
+        # otherwise look identical in the output.
+        alt_match_version = None
         for n in range(1, MAX_VOTE_VERSIONS + 1):
             try:
                 ev_bytes = ipfs_get(gateway, f"{dins['evidenceCid']}/vote-{voter}-v{n}.json")
@@ -1647,11 +1722,16 @@ def audit_one_ballot(report: Report, fingerprint: str, pair: dict, gateway: str,
                 break
             probed = n
             ev = json.loads(ev_bytes)
-            compact = json.dumps(ev, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+            compact = evidence_hash_bytes(ev, spec_major)
             if blake2b_256(compact).hex() == expected:
                 matched_version = n
                 matched_obj = ev
                 break
+            if alt_match_version is None:
+                alt = json.dumps(ev, separators=(",", ":"), ensure_ascii=False,
+                                 sort_keys=not canonical_evidence).encode("utf-8")
+                if blake2b_256(alt).hex() == expected:
+                    alt_match_version = n
         if matched_version is not None:
             report.ok(f"voter {voter} -> v{matched_version} matches committed voteHash")
             matched_evidence[voter] = {"version": matched_version, "evidence": matched_obj}
@@ -1683,6 +1763,11 @@ def audit_one_ballot(report: Report, fingerprint: str, pair: dict, gateway: str,
                 extra = f" (hit MAX_VOTE_VERSIONS={MAX_VOTE_VERSIONS} safety cap — raise it if a voter legitimately voted this many times)"
             else:
                 extra = f" (probed v1..v{probed})"
+            if alt_match_version is not None:
+                other = "insertion order" if canonical_evidence else "canonical (sorted keys)"
+                extra += (f"; NOTE: v{alt_match_version} DOES match under {other}, so this is an"
+                          f" encoding mismatch, not tampering. specVersion {spec_version!r} selected"
+                          f" {encoding}; check CANONICAL_EVIDENCE_MIN_MAJOR against the producer.")
             report.fail(f"voter {voter} -> committed voteHash matched no evidence version{extra}")
 
     # --- Step 7: COSE_Sign1 signatures verify -------------------------------

--- a/hydra/responder-role-derivation.md
+++ b/hydra/responder-role-derivation.md
@@ -1,0 +1,91 @@
+---
+layout: default
+title: responderRole is server-derived
+description: Wire-format change for POST /vote and POST /vote-and-register on the Hydra middleware. The responderRole field is no longer accepted from clients; it is derived from the voter's bech32 HRP before evidence is hashed.
+---
+
+# `responderRole` is now server-derived
+
+**Effective:** Hydra middleware, all releases following the issue #1 fix.
+**Affected endpoints:** `POST /vote`, `POST /vote-and-register`.
+**Breakage:** None for well-behaved callers. Stale `responderRole` fields are
+silently ignored; the server always emits the canonical value.
+
+## What changed
+
+Previously, the Hydra middleware accepted a `responderRole` string in the
+request body of `POST /vote` and `POST /vote-and-register` and copied it
+verbatim into the IPFS-pinned `VoteEvidence` object. That evidence is
+`blake2b_256`-hashed into the on-chain `voteHash`, so a client-supplied
+value became part of the immutable commitment.
+
+The middleware now ignores any `responderRole` on the request body. It
+derives the value from the bech32 HRP of `voterId` and writes that into
+the evidence object before hashing.
+
+The mapping (canonical, lowercase, three-role space):
+
+| Bech32 HRP   | `responderRole` in evidence |
+|--------------|-----------------------------|
+| `drep`       | `drep`                      |
+| `pool`       | `pool`                      |
+| `calidus`    | `pool`                      |
+| `stake`      | `stake`                     |
+| `stake_test` | `stake`                     |
+
+`addr` and `addr_test` (payment credentials) and CC identities have always
+been rejected at the wire by the middleware and remain so.
+
+## What downstream consumers need to do
+
+### Vote-broker / backend integrators
+
+- Stop sending `responderRole` on the wire to the Hydra middleware. Any
+  value supplied is dropped at the route boundary; it never reaches the
+  evidence object. There is no functional difference between sending the
+  field and omitting it, but sending it is misleading to anyone reading
+  HTTP traces.
+- The shape of `VoteEvidence` is unchanged. `responderRole` is still a
+  required field on the JSON pinned to IPFS — only the *source* of the
+  value has changed (server-derived vs. client-supplied).
+- The on-chain `voteHash` is `blake2b_256` of the canonical JSON of
+  `VoteEvidence`. Auditors recomputing the hash should use the
+  server-derived role value, which they can independently rederive from
+  the bech32 HRP of `voterId` recorded in `ekklesia.credentialHrp`.
+
+### Direct API users
+
+If you've been hard-coding `responderRole: "DRep"` (mixed case) or any
+other value in your request bodies, you can delete that field. The
+canonical lowercase role names (`drep`, `pool`, `stake`) are derived for
+you. Mixed-case variants from earlier API versions (`DRep`, `SPO`,
+`Stakeholder`) were already non-canonical in the tally layer; the fix
+makes them inexpressible at submission time as well.
+
+### Auditors
+
+- Tallies in `results.json` were already keyed on the HRP-derived role
+  (`HRP_TO_ROLE[credentialHrp]` with `evidence.responderRole` only as a
+  fallback). No `results.json` schema change.
+- Evidence verification: `evidence.responderRole` is now guaranteed to
+  agree with `evidence.ekklesia.credentialHrp` for any vote pinned after
+  this change. A mismatch in older evidence indicates a vote pinned under
+  the prior, vulnerable code path and should be treated as suspect.
+
+## Why
+
+`POST /vote` and `POST /vote-and-register` accept signed vote payloads
+from any caller holding the Hydra API key. The signature proves control
+of the voter credential, but it does not prove the role claim — the role
+field was never part of the signed payload. Accepting it from the client
+created a permanent, on-chain commitment to a value the voter never
+signed for. Deriving from the bech32 HRP (which *is* part of the signed
+payload, via `voterId`) closes that gap.
+
+## Reference
+
+- Issue: [ekklesia-hydra#1](https://github.com/Lerna-Labs/ekklesia-hydra/issues/1)
+- Companion fix at the broker layer: ekklesia-backend#39 (tracked
+  separately; the middleware fix alone is sufficient for the middleware
+  surface, but until the broker fix lands, callers going through the
+  broker may still produce mismatched evidence).


### PR DESCRIPTION
## Summary

- Updates to audit_ballot.py to support the new, RFC8785 canonical JSON format required for signatures in Ekklesia specVersion 2.0
- Update some info about responder role derivation.

## Checklist

- [x] Markdown is formatted (`npm run fmt:check`)
- [x] OpenAPI specs validate (`npm run lint:specs`), if specs were touched
- [x] Changelog entry added (`npx changeset`), `patch` for editorial work,
      `minor` for substantive changes
