### PR TITLE
Stop Dependabot from opening pull requests automatically

### DIFF
--- a/.changeset/stop-dependabot-pull-requests.md
+++ b/.changeset/stop-dependabot-pull-requests.md
@@ -1,0 +1,5 @@
+---
+---
+
+Dependabot no longer opens pull requests in this repository; alerts stay enabled
+and dependency updates land as maintainer-authored batches carrying a changeset.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,18 @@
 version: 2
+# Automatic pull requests are disabled: open-pull-requests-limit is 0 on every
+# block below. Dependabot alerts stay enabled and are the signal; dependency
+# updates land as maintainer-authored batches that carry a changeset, which an
+# automated pull request cannot provide. Dependabot security updates are
+# disabled in repository settings for the same reason.
+#
+# To re-enable, restore a non-zero open-pull-requests-limit here and turn
+# Dependabot security updates back on in repository settings.
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
+    open-pull-requests-limit: 0
     cooldown:
       default-days: 3
       semver-patch-days: 3
@@ -19,6 +28,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    open-pull-requests-limit: 0
     cooldown:
       default-days: 3
       semver-patch-days: 3
@@ -32,6 +42,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    open-pull-requests-limit: 0
     cooldown:
       default-days: 7
     groups:


### PR DESCRIPTION
Sets `open-pull-requests-limit: 0` on all three update blocks in `.github/dependabot.yml` (npm, bundler, github-actions), so Dependabot stops opening pull requests here.

Dependabot pull requests cannot carry a changeset entry, so the changelog gate cannot pass on them and they can never be promoted through the Changesets release flow. Dependabot alerts stay enabled and remain the signal for dependency work; updates land instead as maintainer-authored batches that carry a real changeset.

The `cooldown` and `groups` blocks, and the `ruby/setup-ruby` ignore entry with its comment, are unchanged. A comment at the top of the file records why automatic pull requests are off and how to re-enable them.

Closes #86
