### PR TITLE
Pin fast-uri past its high-severity advisories

### DIFF
--- a/.changeset/patch-fast-uri-high-severity.md
+++ b/.changeset/patch-fast-uri-high-severity.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Pin fast-uri to 3.1.6 or later via an npm override. It is a transitive dependency of ajv, which openapi-to-postmanv2 uses to validate schemas while generating the downloadable Postman collections. This closes GHSA-4c8g-83qw-93j6, GHSA-v2hh-gcrm-f6hx, GHSA-7p8r-x3mc-p8w7, GHSA-q3j6-qgpj-74h6, GHSA-v39h-62p7-jpjc, GHSA-f65p-4m7j-42xc, and GHSA-jqff-g426-hqxp in the build tooling.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3025,9 +3025,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "read-yaml-file": {
       "js-yaml": "^3.15.1"
     },
-    "lodash": "^4.18.1"
+    "lodash": "^4.18.1",
+    "fast-uri": "^3.1.6"
   }
 }


### PR DESCRIPTION
Adds an npm override forcing fast-uri to 3.1.6 or later. It is a transitive dependency of ajv, which openapi-to-postmanv2 uses to validate schemas while generating the downloadable Postman collections.

Closes GHSA-4c8g-83qw-93j6, GHSA-v2hh-gcrm-f6hx, GHSA-7p8r-x3mc-p8w7, GHSA-q3j6-qgpj-74h6, GHSA-v39h-62p7-jpjc, GHSA-f65p-4m7j-42xc, and GHSA-jqff-g426-hqxp (Dependabot alerts #11, #12, #15, #19, #20, #24, #25).

ajv declares fast-uri with a floating `^3.0.1` range and this repo has a single resolved copy in the lockfile, so the override is a clean pin rather than a version-jump workaround.