### PR TITLE
Scope changelog-check workflow permissions to contents:read

### DIFF
--- a/.changeset/scope-changelog-check-permissions.md
+++ b/.changeset/scope-changelog-check-permissions.md
@@ -1,0 +1,6 @@
+---
+---
+
+The changelog-check workflow now declares contents:read as its only permission,
+since checking out the repository and diffing against the base branch is all the
+job does.

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   changeset:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The changelog-check job only checks out the repository and runs a local `git diff` against the base branch to look for a changeset file. It never writes to the repository, issues, or pull requests, so it does not need the default read-write token scope GitHub grants a workflow with no `permissions:` block. Adds a top-level `permissions: contents: read` block, which is all the checkout step needs.

Addresses the missing-workflow-permissions code scanning alert at .github/workflows/changelog-check.yml:10.

Carries a changeset rather than the `skip-changelog` label: this repository's changelog-check job only exempts the Dependabot and release-manager identities, and does not read that label, so applying it here would leave the check failing.
